### PR TITLE
docs: normalize XML documentation across core packages

### DIFF
--- a/src/Dx.Domain.Annotations/ApprovedKernelApiAttribute.cs
+++ b/src/Dx.Domain.Annotations/ApprovedKernelApiAttribute.cs
@@ -1,5 +1,15 @@
-// Copyright (c) Dx.Domain Contributors. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
+// <authors>Ulf Bourelius (Original Author)</authors>
+// <copyright file="ApprovedKernelApiAttribute.cs" company="Dx.Domain Team">
+//     Copyright (c) 2025 Dx.Domain Team. All rights reserved.
+// </copyright>
+// <license>
+//     This software is licensed under the MIT License.
+//     See the project's root <c>LICENSE</c> file for details.
+//     Contributions are welcome, subject to the terms of the project's license.
+//     See the repository root <c>CONTRIBUTING.md</c> file for details.
+// </license>
+// ----------------------------------------------------------------------------------
+
 
 using System;
 

--- a/src/Dx.Domain.Annotations/CHANGELOG.md
+++ b/src/Dx.Domain.Annotations/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## [0.1.0] - 2026-01-17
+### Added
+- Initial public release
+- AggregateRootAttribute, EntityAttribute, ValueObjectAttribute, DomainServiceAttribute, ApplicationServiceAttribute, RepositoryAttribute, FactoryAttribute, DomainEventAttribute, SpecificationAttribute
+- DpiJustifiedAttribute
+- Scope, ExceptionIntent enums
+- IIdentity interface

--- a/src/Dx.Domain.Annotations/DpiJustifiedAttribute.cs
+++ b/src/Dx.Domain.Annotations/DpiJustifiedAttribute.cs
@@ -1,16 +1,24 @@
-// Copyright (c) Dx.Domain Contributors. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
+// <authors>Ulf Bourelius (Original Author)</authors>
+// <copyright file="DpiJustifiedAttribute.cs" company="Dx.Domain Team">
+//     Copyright (c) 2025 Dx.Domain Team. All rights reserved.
+// </copyright>
+// <license>
+//     This software is licensed under the MIT License.
+//     See the project's root <c>LICENSE</c> file for details.
+//     Contributions are welcome, subject to the terms of the project's license.
+//     See the repository root <c>CONTRIBUTING.md</c> file for details.
+// </license>
+// ----------------------------------------------------------------------------------
 
 using System;
 
 namespace Dx.Domain.Annotations;
 
 /// <summary>
-/// Documents a deviation from standard patterns with a DPI‑aligned justification (pure metadata marker).
+/// Documents a deviation from standard patterns with a DPI-aligned justification (pure metadata marker).
 /// </summary>
 /// <remarks>
-/// This attribute imposes no runtime semantics; it records rationale for code review
-/// and audit trails. SEE: Governance Docs → DPI / ADR Process.
+/// This attribute imposes no runtime semantics. It records rationale for code review and audit trails. See Governance Docs → DPI / ADR Process.
 ///
 /// <para><b>Example (non‑prescriptive):</b></para>
 /// <code><![CDATA[

--- a/src/Dx.Domain.Annotations/Dx.Domain.Annotations.csproj
+++ b/src/Dx.Domain.Annotations/Dx.Domain.Annotations.csproj
@@ -11,7 +11,8 @@
     <Authors>Dx.Domain Team</Authors>
     <Company>Dx.Domain Team</Company>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <NoWarn>$(NoWarn);CS1591</NoWarn>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+    <!--<NoWarn>$(NoWarn);CS1591</NoWarn>-->
     <Nullable>enable</Nullable>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/ulfbou/dx.domain</RepositoryUrl>
@@ -42,8 +43,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="CHANGELOG.md" Link="docs/CHANGELOG.md" />
-    <None Update="README.md"     Link="docs/README.md" />
+    <None Include="CHANGELOG.md" Pack="true" PackagePath="/" />
+    <None Include="README.md" Pack="true" PackagePath="/" />
     <None Update="..\..\LICENSE" Link="docs/LICENSE" />
   </ItemGroup>
 </Project>

--- a/src/Dx.Domain.Annotations/DxApprovedHandlerAttribute.cs
+++ b/src/Dx.Domain.Annotations/DxApprovedHandlerAttribute.cs
@@ -1,5 +1,14 @@
-// Copyright (c) Dx.Domain Contributors. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
+// <authors>Ulf Bourelius (Original Author)</authors>
+// <copyright file="DxApprovedHandlerAttribute.cs" company="Dx.Domain Team">
+//     Copyright (c) 2025 Dx.Domain Team. All rights reserved.
+// </copyright>
+// <license>
+//     This software is licensed under the MIT License.
+//     See the project's root <c>LICENSE</c> file for details.
+//     Contributions are welcome, subject to the terms of the project's license.
+//     See the repository root <c>CONTRIBUTING.md</c> file for details.
+// </license>
+// ----------------------------------------------------------------------------------
 
 using System;
 

--- a/src/Dx.Domain.Annotations/DxFacadeAttribute.cs
+++ b/src/Dx.Domain.Annotations/DxFacadeAttribute.cs
@@ -1,5 +1,14 @@
-// Copyright (c) Dx.Domain Contributors. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
+// <authors>Ulf Bourelius (Original Author)</authors>
+// <copyright file="DxFacadeAttribute.cs" company="Dx.Domain Team">
+//     Copyright (c) 2025 Dx.Domain Team. All rights reserved.
+// </copyright>
+// <license>
+//     This software is licensed under the MIT License.
+//     See the project's root <c>LICENSE</c> file for details.
+//     Contributions are welcome, subject to the terms of the project's license.
+//     See the repository root <c>CONTRIBUTING.md</c> file for details.
+// </license>
+// ----------------------------------------------------------------------------------
 
 using System;
 
@@ -9,29 +18,27 @@ namespace Dx.Domain.Annotations;
 /// Marks a class as an approved domain facade boundary (pure metadata marker).
 /// </summary>
 /// <remarks>
-/// This attribute does not impose return-type or behavioral contracts. Analyzers
-/// classify construction boundaries per DXA010/011/080.
-/// SEE: Rule Charter → DXA010 Construction Discipline.
+/// This attribute imposes no runtime semantics. Analyzers classify construction boundaries per DXA010/011/080. See Rule Charter → DXA010 Construction Discipline.
 ///
 /// <para><b>Example (Kernel realization, non‑prescriptive):</b></para>
 /// <code><![CDATA[
 /// [DxFacade]
 /// public static class OrderFacade
 /// {
-///     public static Result<Order> CreateOrder(CustomerId customerId, ...)
+///     public static Result<Order> CreateOrder(CustomerId customerId,...)
 ///     {
 ///         // boundary validation + construction
-///         return Result.Success(new Order(customerId, ...));
+///         return Result.Success(new Order(customerId,...));
 ///     }
 /// }
 /// ]]></code>
-/// 
+///
 /// <para><b>Example (Usage, non‑prescriptive):</b></para>
 /// <code><![CDATA[
-/// var created = OrderFacade.CreateOrder(customerId, ...);
+/// var created = OrderFacade.CreateOrder(customerId,...);
 /// return created.Match(
-///   onSuccess: o => Ok(o),
-///   onFailure: e => BadRequest(e.Code));
+///     onSuccess: o => Ok(o),
+///     onFailure: e => BadRequest(e.Code));
 /// ]]></code>
 /// </remarks>
 [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]

--- a/src/Dx.Domain.Annotations/DxGeneratedAttribute.cs
+++ b/src/Dx.Domain.Annotations/DxGeneratedAttribute.cs
@@ -1,5 +1,14 @@
-// Copyright (c) Dx.Domain Contributors. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
+// <authors>Ulf Bourelius (Original Author)</authors>
+// <copyright file="DxGeneratedAttribute.cs" company="Dx.Domain Team">
+//     Copyright (c) 2025 Dx.Domain Team. All rights reserved.
+// </copyright>
+// <license>
+//     This software is licensed under the MIT License.
+//     See the project's root <c>LICENSE</c> file for details.
+//     Contributions are welcome, subject to the terms of the project's license.
+//     See the repository root <c>CONTRIBUTING.md</c> file for details.
+// </license>
+// ----------------------------------------------------------------------------------
 
 using System;
 

--- a/src/Dx.Domain.Annotations/DxLayerAttribute.cs
+++ b/src/Dx.Domain.Annotations/DxLayerAttribute.cs
@@ -1,5 +1,14 @@
-// Copyright (c) Dx.Domain Contributors. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
+// <authors>Ulf Bourelius (Original Author)</authors>
+// <copyright file="DxLayerAttribute.cs" company="Dx.Domain Team">
+//     Copyright (c) 2025 Dx.Domain Team. All rights reserved.
+// </copyright>
+// <license>
+//     This software is licensed under the MIT License.
+//     See the project's root <c>LICENSE</c> file for details.
+//     Contributions are welcome, subject to the terms of the project's license.
+//     See the repository root <c>CONTRIBUTING.md</c> file for details.
+// </license>
+// ----------------------------------------------------------------------------------
 
 using System;
 

--- a/src/Dx.Domain.Annotations/DxScopeAttribute.cs
+++ b/src/Dx.Domain.Annotations/DxScopeAttribute.cs
@@ -1,5 +1,14 @@
-// Copyright (c) Dx.Domain Contributors. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
+// <authors>Ulf Bourelius (Original Author)</authors>
+// <copyright file="DxScopeAttribute.cs" company="Dx.Domain Team">
+//     Copyright (c) 2025 Dx.Domain Team. All rights reserved.
+// </copyright>
+// <license>
+//     This software is licensed under the MIT License.
+//     See the project's root <c>LICENSE</c> file for details.
+//     Contributions are welcome, subject to the terms of the project's license.
+//     See the repository root <c>CONTRIBUTING.md</c> file for details.
+// </license>
+// ----------------------------------------------------------------------------------
 
 using System;
 

--- a/src/Dx.Domain.Annotations/FactoryAttribute.cs
+++ b/src/Dx.Domain.Annotations/FactoryAttribute.cs
@@ -1,5 +1,14 @@
-// Copyright (c) Dx.Domain Contributors. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
+// <authors>Ulf Bourelius (Original Author)</authors>
+// <copyright file="FactoryAttribute.cs" company="Dx.Domain Team">
+//     Copyright (c) 2025 Dx.Domain Team. All rights reserved.
+// </copyright>
+// <license>
+//     This software is licensed under the MIT License.
+//     See the project's root <c>LICENSE</c> file for details.
+//     Contributions are welcome, subject to the terms of the project's license.
+//     See the repository root <c>CONTRIBUTING.md</c> file for details.
+// </license>
+// ----------------------------------------------------------------------------------
 
 using System;
 

--- a/src/Dx.Domain.Annotations/IdentityAttribute.cs
+++ b/src/Dx.Domain.Annotations/IdentityAttribute.cs
@@ -1,5 +1,14 @@
-// Copyright (c) Dx.Domain Contributors. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
+// <authors>Ulf Bourelius (Original Author)</authors>
+// <copyright file="IdentityAttribute.cs" company="Dx.Domain Team">
+//     Copyright (c) 2025 Dx.Domain Team. All rights reserved.
+// </copyright>
+// <license>
+//     This software is licensed under the MIT License.
+//     See the project's root <c>LICENSE</c> file for details.
+//     Contributions are welcome, subject to the terms of the project's license.
+//     See the repository root <c>CONTRIBUTING.md</c> file for details.
+// </license>
+// ----------------------------------------------------------------------------------
 
 using System;
 

--- a/src/Dx.Domain.Annotations/InvariantAttribute.cs
+++ b/src/Dx.Domain.Annotations/InvariantAttribute.cs
@@ -1,5 +1,14 @@
-// Copyright (c) Dx.Domain Contributors. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
+// <authors>Ulf Bourelius (Original Author)</authors>
+// <copyright file="InvariantAttribute.cs" company="Dx.Domain Team">
+//     Copyright (c) 2025 Dx.Domain Team. All rights reserved.
+// </copyright>
+// <license>
+//     This software is licensed under the MIT License.
+//     See the project's root <c>LICENSE</c> file for details.
+//     Contributions are welcome, subject to the terms of the project's license.
+//     See the repository root <c>CONTRIBUTING.md</c> file for details.
+// </license>
+// ----------------------------------------------------------------------------------
 
 using System;
 

--- a/src/Dx.Domain.Annotations/PolicyAttribute.cs
+++ b/src/Dx.Domain.Annotations/PolicyAttribute.cs
@@ -1,5 +1,14 @@
-// Copyright (c) Dx.Domain Contributors. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
+// <authors>Ulf Bourelius (Original Author)</authors>
+// <copyright file="PolicyAttribute.cs" company="Dx.Domain Team">
+//     Copyright (c) 2025 Dx.Domain Team. All rights reserved.
+// </copyright>
+// <license>
+//     This software is licensed under the MIT License.
+//     See the project's root <c>LICENSE</c> file for details.
+//     Contributions are welcome, subject to the terms of the project's license.
+//     See the repository root <c>CONTRIBUTING.md</c> file for details.
+// </license>
+// ----------------------------------------------------------------------------------
 
 using System;
 

--- a/src/Dx.Domain.Annotations/README.md
+++ b/src/Dx.Domain.Annotations/README.md
@@ -1,0 +1,27 @@
+# Dx.Domain.Annotations
+
+Semantic vocabulary for Dx.Domain.
+
+## Purpose
+
+Provide pure metadata markers that classify domain concepts for compile-time analysis. Attributes express intent without introducing runtime behavior.
+
+## Guarantees
+
+- attributes impose no runtime semantics
+- identifiers are part of the public governance contract
+- classification is stable across minor versions
+- analyzers treat attributes as authoritative source of truth
+
+## Constraints
+
+- no constructors with logic
+- no dependencies on Dx.Domain.Kernel
+- no reflection-based dispatch at runtime
+- must not alter program behavior
+
+## Role in System
+
+- consumed by Dx.Domain.Analyzers for scope and construction authority checks
+- consumed by Dx.Domain.Generators for code generation
+- ignored by the runtime

--- a/src/Dx.Domain.Facts/CHANGELOG.md
+++ b/src/Dx.Domain.Facts/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## [0.1.0] - 2026-01-17
+### Added
+- IFact, FactMetadata, FactEnvelope<T>, FactBase

--- a/src/Dx.Domain.Facts/Causation.cs
+++ b/src/Dx.Domain.Facts/Causation.cs
@@ -49,7 +49,7 @@ namespace Dx.Domain.Facts
         /// </summary>
         /// <param name="correlationId">The unique identifier that correlates related operations or events.</param>
         /// <param name="traceId">The identifier used to trace the flow of a request or operation across system boundaries.</param>
-        /// <param name="actorId">The identifier of the actor responsible for the operation, or null if not applicable.</param>
+        /// <param name="actorId">The identifier of the actor responsible for the operation, or <see langword="null"/> if not applicable.</param>
         /// <param name="utcTimestamp">The timestamp, in Coordinated Universal Time (UTC), indicating when the causation event occurred.</param>
         private Causation(CorrelationId correlationId, TraceId traceId, UserId? actorId, DateTimeOffset utcTimestamp)
         {

--- a/src/Dx.Domain.Facts/Dx.Domain.Facts.csproj
+++ b/src/Dx.Domain.Facts/Dx.Domain.Facts.csproj
@@ -5,6 +5,10 @@
     <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <Description>The Dx.Domain.Facts package provides immutable, append-only facts for domain knowledge.</Description>
+        <PackageTags>dx;ddd;facts;events;immutability</PackageTags>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Dx.Domain.Facts/Fact.cs
+++ b/src/Dx.Domain.Facts/Fact.cs
@@ -71,15 +71,15 @@ public readonly struct Fact<TPayload> : IDomainFact<TPayload>
     /// <summary>
     /// Creates a new domain fact with the specified type, payload, and causation metadata.
     /// </summary>
-    /// <param name="factType">The logical type or category of the fact. Must not be null or whitespace.</param>
-    /// <param name="payload">The fact payload. Must not be null.</param>
+    /// <param name="factType">The logical type or category of the fact. Must not be <see langword="null"/> or whitespace.</param>
+    /// <param name="payload">The fact payload. Must not be <see langword="null"/>.</param>
     /// <param name="causation">The causation metadata associated with this fact.</param>
     /// <param name="utcTimestamp">
-    /// The UTC timestamp when the fact occurred. If null, the current UTC time is used.
+    /// The UTC timestamp when the fact occurred. If <see langword="null"/>, the current UTC time is used.
     /// </param>
     /// <returns>A new <see cref="Fact{TPayload}"/> instance.</returns>
     /// <exception cref="ArgumentNullException">
-    /// Thrown if <paramref name="factType"/> or <paramref name="payload"/> is null.
+    /// Thrown if <paramref name="factType"/> or <paramref name="payload"/> is <see langword="null"/>.
     /// </exception>
     /// <exception cref="ArgumentException">
     /// Thrown if <paramref name="factType"/> is whitespace.
@@ -107,11 +107,11 @@ public readonly struct Fact<TPayload> : IDomainFact<TPayload>
     /// <summary>
     /// Tries to create a new domain fact with the specified type, payload, and causation metadata.
     /// </summary>
-    /// <param name="factType">The logical type or category of the fact. Must not be null or whitespace.</param>
-    /// <param name="payload">The fact payload. Must not be null.</param>
+    /// <param name="factType">The logical type or category of the fact. Must not be <see langword="null"/> or whitespace.</param>
+    /// <param name="payload">The fact payload. Must not be <see langword="null"/>.</param>
     /// <param name="causation">The causation metadata associated with this fact.</param>
     /// <param name="utcTimestamp">
-    /// The UTC timestamp when the fact occurred. If null, the current UTC time is used.
+    /// The UTC timestamp when the fact occurred. If <see langword="null"/>, the current UTC time is used.
     /// </param>
     /// <returns>A <see cref="Result{TValue}"/> containing the new fact or a failure error.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Dx.Domain.Kernel/CHANGELOG.md
+++ b/src/Dx.Domain.Kernel/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [0.1.0] - 2026-01-17
+### Added
+- Result, Result<T>, Result<T,E>, Unit, DomainError
+- Dx facade (Create, Ok, Fail)
+- Map, Bind, Match, Tap, Ensure
+- Instant (UTC-only)

--- a/src/Dx.Domain.Kernel/DomainTime.cs
+++ b/src/Dx.Domain.Kernel/DomainTime.cs
@@ -17,18 +17,41 @@ using static Dx.Domain.Dx;
 namespace Dx.Domain
 {
     /// <summary>
-    /// Value object representing a UTC timestamp used by the kernel.
-    /// Kernel policy: only monotonic checks; no clock correction.
+    /// Represents a UTC timestamp used by the kernel.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This type is immutable and thread-safe. It carries no mutable state.
+    /// </para>
+    /// <para>
+    /// Kernel policy: only monotonic checks are performed; no clock correction is applied.
+    /// </para>
+    /// <para>
+    /// The <see cref="Utc"/> value is always normalized to UTC with an offset of zero.
+    /// </para>
+    /// </remarks>
     public readonly record struct DomainTime
     {
+        /// <summary>
+        /// Gets the UTC timestamp.
+        /// </summary>
         public DateTimeOffset Utc { get; }
 
         private DomainTime(DateTimeOffset utc) => Utc = utc;
 
+        /// <summary>
+        /// Gets the current timestamp.
+        /// </summary>
+        /// <returns>A new <see cref="DomainTime"/> representing the current UTC time.</returns>
         public static DomainTime Now()
             => new(DateTimeOffset.UtcNow);
 
+        /// <summary>
+        /// Creates a <see cref="DomainTime"/> from the specified UTC value.
+        /// </summary>
+        /// <param name="utc">The UTC value. Must have an offset of zero.</param>
+        /// <returns>A new <see cref="DomainTime"/> instance.</returns>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="utc"/> does not have an offset of zero.</exception>
         internal static DomainTime From(DateTimeOffset utc)
         {
             Invariant.That(

--- a/src/Dx.Domain.Kernel/Dx.Domain.Kernel.csproj
+++ b/src/Dx.Domain.Kernel/Dx.Domain.Kernel.csproj
@@ -8,7 +8,8 @@
     <Description>The Dx.Domain.Kernel package provides a small, opinionated kernel for invariants, results, and errors.</Description>
     <PackageTags>dx;ddd;functional;result-pattern;invariants;errors</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <NoWarn>$(NoWarn);CS1591</NoWarn>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+    <!--<NoWarn>$(NoWarn);CS1591</NoWarn>-->
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
@@ -53,8 +54,8 @@
 
   <ItemGroup>
     <None Include="buildTransitive\Dx.Domain.Kernel.targets" Pack="true" PackagePath="buildTransitive" />
-    <None Update="..\..\CHANGELOG.md" Link="docs/CHANGELOG.md" />
-    <None Update="..\..\README.md" Link="docs/README.md" />
+    <None Include="CHANGELOG.md" Pack="true" PackagePath="/" />
+    <None Include="README.md" Pack="true" PackagePath="/" />
     <None Update="..\..\LICENSE" Link="docs/LICENSE" />
   </ItemGroup>
 </Project>

--- a/src/Dx.Domain.Kernel/DxK.cs
+++ b/src/Dx.Domain.Kernel/DxK.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Dx.Domain Contributors. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Dx.Domain.Annotations;
 using Dx.Domain.Errors;
 
 using System.Runtime.CompilerServices;
@@ -57,7 +58,7 @@ internal static class DxK
         /// <summary>Domain transition violated invariants.</summary>
         public const string Domain_InvalidTransition = "dx.kernel.domain.invalid_transition";
 
-        /// <summary>Fact payload was null when required.</summary>
+        /// <summary>Fact payload was <see langword="null"/> when required.</summary>
         public const string Domain_FactPayloadNull = "dx.kernel.domain.fact_payload_null";
 
         /// <summary>Identity value format is invalid.</summary>

--- a/src/Dx.Domain.Kernel/Errors/DomainError.cs
+++ b/src/Dx.Domain.Kernel/Errors/DomainError.cs
@@ -49,9 +49,9 @@ namespace Dx.Domain.Errors
         /// <summary>
         /// Creates a new instance of the DomainError class with the specified error code and message.
         /// </summary>
-        /// <param name="code">The unique code that identifies the type of domain error. Cannot be null or empty.</param>
-        /// <param name="message">The descriptive message that explains the error. Cannot be null.</param>
-        /// <param name="metadata">Metadata associated with the error. Cannot be null.</param>
+        /// <param name="code">The unique code that identifies the type of domain error. Cannot be <see langword="null"/> or empty.</param>
+        /// <param name="message">The descriptive message that explains the error. Cannot be <see langword="null"/>.</param>
+        /// <param name="metadata">Metadata associated with the error. Cannot be <see langword="null"/>.</param>
         /// <returns>A new DomainError instance initialized with the specified code and message.</returns>
         public static DomainError Create(string code, string message, ImmutableArray<KeyValuePair<string, object>>? metadata = null)
             => new(code, message, metadata: metadata ?? ImmutableArray<KeyValuePair<string, object>>.Empty);
@@ -59,8 +59,8 @@ namespace Dx.Domain.Errors
         /// <summary>
         /// Returns a new instance of the current error with the specified metadata key and value added or updated.
         /// </summary>
-        /// <param name="key">The metadata key to add or update. Cannot be null.</param>
-        /// <param name="value">The value to associate with the specified metadata key. Cannot be null.</param>
+        /// <param name="key">The metadata key to add or update. Cannot be <see langword="null"/>.</param>
+        /// <param name="value">The value to associate with the specified metadata key. Cannot be <see langword="null"/>.</param>
         /// <returns>A new <see cref="DomainError"/> instance that includes the specified metadata key and value.</returns>
         public DomainError Enrich(string key, string value)
             => this with { Metadata = Metadata.SetItem(key, value) };

--- a/src/Dx.Domain.Kernel/Kernel/Dx.Require.cs
+++ b/src/Dx.Domain.Kernel/Kernel/Dx.Require.cs
@@ -33,27 +33,26 @@ using Dx.Domain.Errors;
 
 namespace Dx.Domain
 {
+    /// <summary>
+    /// Represents the primary entry point for Dx.Domain kernel operations.
+    /// </summary>
+    /// <remarks>
+    /// This type provides factory and guard methods for domain construction. It imposes no mutable state and is thread-safe.
+    /// </remarks>
     public static partial class Dx
     {
         /// <summary>
-        /// Provides validation‑style invariant checks that return failed Results
-        /// instead of throwing exceptions.
+        /// Represents validation-style invariant checks that return failed Results instead of throwing exceptions.
         /// </summary>
         /// <remarks>
         /// <para>
-        /// <c>Require</c> represents <em>recoverable domain validation</em>.
-        /// A failed requirement indicates that an operation cannot proceed,
-        /// but does not represent a corrupted program state or programming error.
+        /// <c>Require</c> represents <em>recoverable domain validation</em>. A failed requirement indicates that an operation cannot proceed, but does not represent a corrupted program state or programming error.
         /// </para>
         /// <para>
-        /// In contrast to <see cref="Invariant"/>, methods on this class
-        /// <strong>never throw</strong> as a result of validation failure.
-        /// All outcomes are expressed as <see cref="Result"/> values and are therefore
-        /// composable, inspectable, and analyzable.
+        /// In contrast to <see cref="Invariant"/>, methods on this class <strong>never throw</strong> as a result of validation failure. All outcomes are expressed as <see cref="Result"/> values and are therefore composable, inspectable, and analyzable.
         /// </para>
         /// <para>
-        /// This class is the primary validation surface intended for third‑party,
-        /// application‑level, and flow‑oriented domain logic.
+        /// This class is the primary validation surface intended for third-party, application-level, and flow-oriented domain logic.
         /// </para>
         /// </remarks>
         /// <seealso cref="Invariant"/>
@@ -65,24 +64,14 @@ namespace Dx.Domain
             // -----------------------------------------------------------------
 
             /// <summary>
-            /// Validates that the specified condition holds using an eagerly supplied
-            /// <see cref="InvariantError"/>.
+            /// Validates that the specified condition holds using an eagerly supplied <see cref="InvariantError"/>.
             /// </summary>
-            /// <param name="condition">
-            /// The condition to evaluate.
-            /// </param>
-            /// <param name="error">
-            /// The invariant error describing the validation failure.
-            /// The error value is captured eagerly.
-            /// </param>
-            /// <returns>
-            /// A successful <see cref="Result{Unit}"/> if the condition holds;
-            /// otherwise a failed Result containing <paramref name="error"/>.
-            /// </returns>
+            /// <param name="condition">The condition to evaluate.</param>
+            /// <param name="error">The invariant error describing the validation failure. The error value is captured eagerly.</param>
+            /// <returns>A successful <see cref="Result{Unit}"/> if the condition holds; otherwise a failed Result containing <paramref name="error"/>.</returns>
             /// <remarks>
             /// <para>
-            /// This overload should be used when error construction is inexpensive
-            /// and independent of runtime context.
+            /// This overload should be used when error construction is inexpensive and independent of runtime context.
             /// </para>
             /// </remarks>
             public static Result<Unit> That(
@@ -96,25 +85,14 @@ namespace Dx.Domain
             }
 
             /// <summary>
-            /// Validates that the specified condition holds using lazy
-            /// <see cref="DomainError"/> construction.
+            /// Validates that the specified condition holds using lazy <see cref="DomainError"/> construction.
             /// </summary>
-            /// <param name="condition">
-            /// The condition to evaluate.
-            /// </param>
-            /// <param name="errorFactory">
-            /// A factory that lazily produces the domain error.
-            /// The factory is invoked only when the condition fails.
-            /// </param>
-            /// <returns>
-            /// A successful <see cref="Result{Unit}"/> if the condition holds;
-            /// otherwise a failed Result containing the produced error.
-            /// </returns>
+            /// <param name="condition">The condition to evaluate.</param>
+            /// <param name="errorFactory">A factory that lazily produces the domain error. The factory is invoked only when the condition fails.</param>
+            /// <returns>A successful <see cref="Result{Unit}"/> if the condition holds; otherwise a failed Result containing the produced error.</returns>
             /// <remarks>
             /// <para>
-            /// This overload avoids unnecessary allocations on successful code paths
-            /// and allows richer contextual information to be captured at the point
-            /// of failure.
+            /// This overload avoids unnecessary allocations on successful code paths and allows richer contextual information to be captured at the point of failure.
             /// </para>
             /// </remarks>
             public static Result<Unit> That(
@@ -132,26 +110,15 @@ namespace Dx.Domain
             // -----------------------------------------------------------------
 
             /// <summary>
-            /// Validates that the specified condition holds using an eagerly supplied
-            /// <see cref="DomainError"/>.
+            /// Validates that the specified condition holds using an eagerly supplied <see cref="DomainError"/>.
             /// </summary>
-            /// <param name="condition">
-            /// The condition to evaluate.
-            /// </param>
-            /// <param name="value">
-            /// The value to wrap in the result if the condition holds.
-            /// </param>
-            /// <param name="error">
-            /// The domain error describing the validation failure.
-            /// </param>
-            /// <returns>
-            /// A successful <see cref="Result{Unit}"/> if the condition holds;
-            /// otherwise a failed Result containing <paramref name="error"/>.
-            /// </returns>
+            /// <param name="condition">The condition to evaluate.</param>
+            /// <param name="value">The value to wrap in the result if the condition holds.</param>
+            /// <param name="error">The domain error describing the validation failure.</param>
+            /// <returns>A successful <see cref="Result{TValue}"/> if the condition holds; otherwise a failed Result containing <paramref name="error"/>.</returns>
             /// <remarks>
             /// <para>
-            /// Domain errors typically represent business-rule violations
-            /// or invalid user input rather than structural domain corruption.
+            /// Domain errors typically represent business-rule violations or invalid user input rather than structural domain corruption.
             /// </para>
             /// </remarks>
             public static Result<TValue> That<TValue>(
@@ -160,31 +127,19 @@ namespace Dx.Domain
                 DomainError error)
                 where TValue : notnull
                 => condition
-                    ? Result.Success<TValue>(value)
+                   ? Result.Success<TValue>(value)
                     : Result.Failure<TValue>(error);
 
             /// <summary>
-            /// Validates that the specified condition holds using lazy
-            /// <see cref="DomainError"/> construction.
+            /// Validates that the specified condition holds using lazy <see cref="DomainError"/> construction.
             /// </summary>
-            /// <param name="condition">
-            /// The condition to evaluate.
-            /// </param>
-            /// <param name="value">
-            /// The value to wrap in the result if the condition holds.
-            /// </param>
-            /// <param name="errorFactory">
-            /// A factory that lazily produces the domain error.
-            /// The factory is invoked only when the condition fails.
-            /// </param>
-            /// <returns>
-            /// A successful <see cref="Result{TValue}"/> if the condition holds;
-            /// otherwise a failed Result containing the produced error.
-            /// </returns>
+            /// <param name="condition">The condition to evaluate.</param>
+            /// <param name="value">The value to wrap in the result if the condition holds.</param>
+            /// <param name="errorFactory">A factory that lazily produces the domain error. The factory is invoked only when the condition fails.</param>
+            /// <returns>A successful <see cref="Result{TValue}"/> if the condition holds; otherwise a failed Result containing the produced error.</returns>
             /// <remarks>
             /// <para>
-            /// This overload should be preferred when error construction depends
-            /// on runtime state or diagnostic context.
+            /// This overload should be preferred when error construction depends on runtime state or diagnostic context.
             /// </para>
             /// </remarks>
             public static Result<TValue> That<TValue>(
@@ -201,29 +156,17 @@ namespace Dx.Domain
             // -----------------------------------------------------------------
 
             /// <summary>
-            /// Validates that the specified condition holds using an eagerly supplied
-            /// strongly typed error value.
+            /// Validates that the specified condition holds using an eagerly supplied strongly typed error value.
             /// </summary>
-            /// <typeparam name="TError">
-            /// The type of the error value.
-            /// </typeparam>
-            /// <param name="condition">
-            /// The condition to evaluate.
-            /// </param>
-            /// <param name="error">
-            /// The error value describing the validation failure.
-            /// </param>
-            /// <returns>
-            /// A successful <see cref="Result{Unit, TError}"/> if the condition holds;
-            /// otherwise a failed Result containing <paramref name="error"/>.
-            /// </returns>
+            /// <typeparam name="TError">The type of the error value.</typeparam>
+            /// <param name="condition">The condition to evaluate.</param>
+            /// <param name="error">The error value describing the validation failure.</param>
+            /// <returns>A successful <see cref="Result{Unit, TError}"/> if the condition holds; otherwise a failed Result containing <paramref name="error"/>.</returns>
             /// <remarks>
             /// <para>
-            /// This overload enables domain‑specific error models while preserving
-            /// Result‑based control flow.
+            /// This overload enables domain-specific error models while preserving Result-based control flow.
             /// </para>
             /// </remarks>
-
             public static Result<Unit, TError> That<TError>(
                 bool condition,
                 TError error)
@@ -233,26 +176,15 @@ namespace Dx.Domain
                     : Dx.Result.Failure<Unit, TError>(error);
 
             /// <summary>
-            /// Validates that the specified condition holds using lazy construction
-            /// of a strongly typed error value.
+            /// Validates that the specified condition holds using lazy construction of a strongly typed error value.
             /// </summary>
-            /// <typeparam name="TError">
-            /// The type of the error value.
-            /// </typeparam>
-            /// <param name="condition">
-            /// The condition to evaluate.
-            /// </param>
-            /// <param name="errorFactory">
-            /// A factory that lazily produces the error value.
-            /// </param>
-            /// <returns>
-            /// A successful <see cref="Result{Unit, TError}"/> if the condition holds;
-            /// otherwise a failed Result containing the produced error.
-            /// </returns>
+            /// <typeparam name="TError">The type of the error value.</typeparam>
+            /// <param name="condition">The condition to evaluate.</param>
+            /// <param name="errorFactory">A factory that lazily produces the error value.</param>
+            /// <returns>A successful <see cref="Result{Unit, TError}"/> if the condition holds; otherwise a failed Result containing the produced error.</returns>
             /// <remarks>
             /// <para>
-            /// This overload maximizes composability while avoiding premature
-            /// allocation or capture of error data.
+            /// This overload maximizes composability while avoiding premature allocation or capture of error data.
             /// </para>
             /// </remarks>
             public static Result<Unit, TError> That<TError>(
@@ -263,7 +195,15 @@ namespace Dx.Domain
                     ? Dx.Result.Success<Unit, TError>(Unit.Value)
                     : Dx.Result.Failure<Unit, TError>(errorFactory);
 
-
+            /// <summary>
+            /// Determines whether the specified condition holds and returns the specified value.
+            /// </summary>
+            /// <typeparam name="TValue">The type of the value.</typeparam>
+            /// <typeparam name="TError">The type of the error.</typeparam>
+            /// <param name="condition">The condition to evaluate.</param>
+            /// <param name="value">The value to return when <paramref name="condition"/> is <see langword="true"/>.</param>
+            /// <param name="error">The error to use when <paramref name="condition"/> is <see langword="false"/>.</param>
+            /// <returns>A successful <see cref="Result{TValue, TError}"/> containing <paramref name="value"/> if the condition holds; otherwise a failed result containing <paramref name="error"/>.</returns>
             public static Result<TValue, TError> That<TValue, TError>(
                 bool condition,
                 TValue value,
@@ -274,7 +214,15 @@ namespace Dx.Domain
                     ? Dx.Result.Success<TValue, TError>(value)
                     : Dx.Result.Failure<TValue, TError>(error);
 
-
+            /// <summary>
+            /// Determines whether the specified condition holds and returns the specified value.
+            /// </summary>
+            /// <typeparam name="TValue">The type of the value.</typeparam>
+            /// <typeparam name="TError">The type of the error.</typeparam>
+            /// <param name="condition">The condition to evaluate.</param>
+            /// <param name="value">The value to return when <paramref name="condition"/> is <see langword="true"/>.</param>
+            /// <param name="errorFactory">The factory that creates the error when <paramref name="condition"/> is <see langword="false"/>.</param>
+            /// <returns>A successful <see cref="Result{TValue, TError}"/> containing <paramref name="value"/> if the condition holds; otherwise a failed result containing the produced error.</returns>
             public static Result<TValue, TError> That<TValue, TError>(
                 bool condition,
                 TValue value,
@@ -282,7 +230,7 @@ namespace Dx.Domain
                 where TValue : notnull
                 where TError : notnull
                 => condition
-                    ? Dx.Result.Success<TValue, TError>(value)
+                   ? Dx.Result.Success<TValue, TError>(value)
                     : Dx.Result.Failure<TValue, TError>(errorFactory);
         }
     }

--- a/src/Dx.Domain.Kernel/README.md
+++ b/src/Dx.Domain.Kernel/README.md
@@ -1,0 +1,15 @@
+# Dx.Domain.Kernel
+
+Functional core for Dx.Domain.
+
+## Purpose
+
+Provide the minimal, frozen set of types required to express domain outcomes without exceptions for control flow.
+
+## Guarantees
+
+- Result<T> must be handled (DXA020)
+- no exceptions for domain control flow
+- UTC-only time representation
+- kernel surface is frozen
+- zero external dependencies

--- a/src/Dx.Domain.Kernel/ResultExtensions.cs
+++ b/src/Dx.Domain.Kernel/ResultExtensions.cs
@@ -28,6 +28,16 @@ namespace Dx.Domain
     {
         #region Map
 
+        /// <summary>
+        /// Transforms the success value of a <see cref="Result{TIn}"/> using the specified mapping function.
+        /// </summary>
+        /// <typeparam name="TIn">The type of the source value. Must be non-nullable.</typeparam>
+        /// <typeparam name="TOut">The type of the mapped value. Must be non-nullable.</typeparam>
+        /// <param name="result">The source result.</param>
+        /// <param name="mapFunc">The mapping function to apply to the success value. Must not be <see langword="null"/>.</param>
+        /// <returns>A new <see cref="Result{TOut}"/> containing the mapped value if <paramref name="result"/> is successful; otherwise, a failure result containing the original error.</returns>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="mapFunc"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="mapFunc"/> throws an exception. The original exception is included as the inner exception.</exception>
         public static Result<TOut> Map<TIn, TOut>(this Result<TIn> result, Func<TIn, TOut> mapFunc)
             where TIn : notnull
             where TOut : notnull
@@ -48,6 +58,16 @@ namespace Dx.Domain
             }
         }
 
+        /// <summary>
+        /// Transforms the success value of a <see cref="Result{TIn}"/> asynchronously using the specified mapping function.
+        /// </summary>
+        /// <typeparam name="TIn">The type of the source value. Must be non-nullable.</typeparam>
+        /// <typeparam name="TOut">The type of the mapped value. Must be non-nullable.</typeparam>
+        /// <param name="result">The source result.</param>
+        /// <param name="map">The asynchronous mapping function to apply to the success value. Must not be <see langword="null"/>.</param>
+        /// <returns>A value task that represents the asynchronous operation. The result contains a new <see cref="Result{TOut}"/> with the mapped value if successful; otherwise, the original error.</returns>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="map"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="map"/> throws an exception. The original exception is included as the inner exception.</exception>
         public static async ValueTask<Result<TOut>> MapAsync<TIn, TOut>(this Result<TIn> result, Func<TIn, Task<TOut>> map)
             where TIn : notnull
             where TOut : notnull
@@ -72,6 +92,16 @@ namespace Dx.Domain
 
         #region Bind
 
+        /// <summary>
+        /// Binds the success value of a <see cref="Result{TIn}"/> to a new result using the specified binding function.
+        /// </summary>
+        /// <typeparam name="TIn">The type of the source value. Must be non-nullable.</typeparam>
+        /// <typeparam name="TOut">The type of the bound value. Must be non-nullable.</typeparam>
+        /// <param name="result">The source result.</param>
+        /// <param name="bindFunc">The binding function to apply to the success value. Must not be <see langword="null"/>.</param>
+        /// <returns>The result produced by <paramref name="bindFunc"/> if <paramref name="result"/> is successful; otherwise, a failure result containing the original error.</returns>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="bindFunc"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="bindFunc"/> throws an exception. The original exception is included as the inner exception.</exception>
         public static Result<TOut> Bind<TIn, TOut>(this Result<TIn> result, Func<TIn, Result<TOut>> bindFunc)
             where TIn : notnull
             where TOut : notnull
@@ -90,6 +120,16 @@ namespace Dx.Domain
             }
         }
 
+        /// <summary>
+        /// Binds the success value of a <see cref="Result{TIn}"/> to a new result asynchronously using the specified binding function.
+        /// </summary>
+        /// <typeparam name="TIn">The type of the source value. Must be non-nullable.</typeparam>
+        /// <typeparam name="TOut">The type of the bound value. Must be non-nullable.</typeparam>
+        /// <param name="result">The source result.</param>
+        /// <param name="bindFunc">The asynchronous binding function to apply to the success value. Must not be <see langword="null"/>.</param>
+        /// <returns>A value task that represents the asynchronous operation. The result contains the bound result if successful; otherwise, the original error.</returns>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="bindFunc"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="bindFunc"/> throws an exception. The original exception is included as the inner exception.</exception>
         public static async ValueTask<Result<TOut>> BindAsync<TIn, TOut>(this Result<TIn> result, Func<TIn, Task<Result<TOut>>> bindFunc)
             where TIn : notnull
             where TOut : notnull
@@ -112,8 +152,17 @@ namespace Dx.Domain
 
         #region Tap
 
-        public static Result<T> Tap<T>(this Result<T> result, Action<T> action)
-            where T : notnull
+        /// <summary>
+        /// Executes the specified action if the result is successful, returning the original result unchanged.
+        /// </summary>
+        /// <typeparam name="TValue">The type of the value. Must be non-nullable.</typeparam>
+        /// <param name="result">The source result.</param>
+        /// <param name="action">The action to execute on the success value. Must not be <see langword="null"/>.</param>
+        /// <returns>The original <paramref name="result"/>.</returns>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="action"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="action"/> throws an exception. The original exception is included as the inner exception.</exception>
+        public static Result<TValue> Tap<TValue>(this Result<TValue> result, Action<TValue> action)
+            where TValue : notnull
         {
             Invariant.That(action is not null, "Result.Tap.ParameterCannotBeNull", "The tap action cannot be null.");
 
@@ -131,8 +180,17 @@ namespace Dx.Domain
             }
         }
 
-        public static async ValueTask<Result<T>> TapAsync<T>(this Result<T> result, Func<T, Task> action)
-            where T : notnull
+        /// <summary>
+        /// Executes the specified asynchronous action if the result is successful, returning the original result unchanged.
+        /// </summary>
+        /// <typeparam name="TValue">The type of the value. Must be non-nullable.</typeparam>
+        /// <param name="result">The source result.</param>
+        /// <param name="action">The asynchronous action to execute on the success value. Must not be <see langword="null"/>.</param>
+        /// <returns>A value task that represents the asynchronous operation. The result contains the original <paramref name="result"/>.</returns>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="action"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="action"/> throws an exception. The original exception is included as the inner exception.</exception>
+        public static async ValueTask<Result<TValue>> TapAsync<TValue>(this Result<TValue> result, Func<TValue, Task> action)
+            where TValue : notnull
         {
             Invariant.That(action is not null, "Result.TapAsync.ParameterCannotBeNull", "The tap action cannot be null.");
 
@@ -154,7 +212,18 @@ namespace Dx.Domain
 
         #region Ensure
 
-        public static Result<T> Ensure<T>(this Result<T> result, Func<T, bool> predicate, DomainError error) where T : notnull
+        /// <summary>
+        /// Ensures the success value satisfies the specified predicate, otherwise returns a failure with the provided error.
+        /// </summary>
+        /// <typeparam name="TValue">The type of the value. Must be non-nullable.</typeparam>
+        /// <param name="result">The source result.</param>
+        /// <param name="predicate">The predicate to evaluate against the success value. Must not be <see langword="null"/>.</param>
+        /// <param name="error">The error to return if <paramref name="predicate"/> returns <see langword="false"/>.</param>
+        /// <returns>The original result if the predicate is satisfied; otherwise, a failure result containing <paramref name="error"/>.</returns>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="predicate"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="predicate"/> throws an exception. The original
+        /// exception is included as the inner exception.</exception>
+        public static Result<TValue> Ensure<TValue>(this Result<TValue> result, Func<TValue, bool> predicate, DomainError error) where TValue : notnull
         {
             Invariant.That(predicate is not null, "Result.Ensure.ParameterCannotBeNull", "The predicate cannot be null.");
 
@@ -165,7 +234,7 @@ namespace Dx.Domain
             {
                 return predicate!(result.Value)
                     ? result
-                    : Result.Failure<T>(error);
+                    : Result.Failure<TValue>(error);
             }
             catch (Exception ex)
             {
@@ -173,7 +242,18 @@ namespace Dx.Domain
             }
         }
 
-        public static Result<T> Ensure<T>(this Result<T> result, Func<T, bool> predicate, Func<DomainError> errorFactory) where T : notnull
+        /// <summary>
+        /// Ensures the success value satisfies the specified predicate, otherwise returns a failure with an error produced by the factory.
+        /// </summary>
+        /// <typeparam name="TValue">The type of the value. Must be non-nullable.</typeparam>
+        /// <param name="result">The source result.</param>
+        /// <param name="predicate">The predicate to evaluate against the success value. Must not be <see langword="null"/>.</param>
+        /// <param name="errorFactory">The factory function that produces the error when the predicate fails. Must not be <see langword="null"/>.</param>
+        /// <returns>The original result if the predicate is satisfied; otherwise, a failure result containing the produced error.</returns>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="predicate"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="errorFactory"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="predicate"/> throws an exception. The original exception is included as the inner exception.</exception>
+        public static Result<TValue> Ensure<TValue>(this Result<TValue> result, Func<TValue, bool> predicate, Func<DomainError> errorFactory) where TValue : notnull
         {
             Invariant.That(predicate is not null, "Result.Ensure.ParameterCannotBeNull", "The predicate cannot be null.");
             Invariant.That(errorFactory is not null, "Result.Ensure.ParameterCannotBeNull", "The error factory cannot be null.");
@@ -185,7 +265,7 @@ namespace Dx.Domain
             {
                 return predicate!(result.Value)
                     ? result
-                    : Result.Failure<T>(errorFactory!());
+                    : Result.Failure<TValue>(errorFactory!());
             }
             catch (Exception ex)
             {
@@ -193,7 +273,17 @@ namespace Dx.Domain
             }
         }
 
-        public static async ValueTask<Result<T>> EnsureAsync<T>(this Result<T> result, Func<T, Task<bool>> predicate, DomainError error) where T : notnull
+        /// <summary>
+        /// Ensures the success value satisfies the specified asynchronous predicate, otherwise returns a failure with the provided error.
+        /// </summary>
+        /// <typeparam name="TValue">The type of the value. Must be non-nullable.</typeparam>
+        /// <param name="result">The source result.</param>
+        /// <param name="predicate">The asynchronous predicate to evaluate against the success value. Must not be <see langword="null"/>.</param>
+        /// <param name="error">The error to return if <paramref name="predicate"/> returns <see langword="false"/>.</param>
+        /// <returns>A value task that represents the asynchronous operation. The result contains the original result if satisfied; otherwise, a failure.</returns>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="predicate"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="predicate"/> throws an exception. The original exception is included as the inner exception.</exception>
+        public static async ValueTask<Result<TValue>> EnsureAsync<TValue>(this Result<TValue> result, Func<TValue, Task<bool>> predicate, DomainError error) where TValue : notnull
         {
             Invariant.That(predicate is not null, "Result.Ensure.ParameterCannotBeNull", "The predicate cannot be null.");
 
@@ -204,7 +294,7 @@ namespace Dx.Domain
             {
                 return await predicate!(result.Value).ConfigureAwait(false)
                     ? result
-                    : Result.Failure<T>(error);
+                    : Result.Failure<TValue>(error);
             }
             catch (Exception ex)
             {
@@ -212,7 +302,18 @@ namespace Dx.Domain
             }
         }
 
-        public static async ValueTask<Result<T>> EnsureAsync<T>(this Result<T> result, Func<T, Task<bool>> predicate, Func<Task<DomainError>> errorFactory) where T : notnull
+        /// <summary>
+        /// Ensures the success value satisfies the specified asynchronous predicate, otherwise returns a failure with an error produced asynchronously.
+        /// </summary>
+        /// <typeparam name="TValue">The type of the value. Must be non-nullable.</typeparam>
+        /// <param name="result">The source result.</param>
+        /// <param name="predicate">The asynchronous predicate to evaluate against the success value. Must not be <see langword="null"/>.</param>
+        /// <param name="errorFactory">The asynchronous factory that produces the error when the predicate fails. Must not be <see langword="null"/>.</param>
+        /// <returns>A value task that represents the asynchronous operation. The result contains the original result if satisfied; otherwise, a failure.</returns>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="predicate"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="errorFactory"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="predicate"/> throws an exception. The original exception is included as the inner exception.</exception>
+        public static async ValueTask<Result<TValue>> EnsureAsync<TValue>(this Result<TValue> result, Func<TValue, Task<bool>> predicate, Func<Task<DomainError>> errorFactory) where TValue : notnull
         {
             Invariant.That(predicate is not null, "Result.Ensure.ParameterCannotBeNull", "The predicate cannot be null.");
             Invariant.That(errorFactory is not null, "Result.Ensure.ParameterCannotBeNull", "The error factory cannot be null.");
@@ -224,7 +325,7 @@ namespace Dx.Domain
             {
                 return await predicate!(result.Value).ConfigureAwait(false)
                     ? result
-                    : Result.Failure<T>(await errorFactory!().ConfigureAwait(false));
+                    : Result.Failure<TValue>(await errorFactory!().ConfigureAwait(false));
             }
             catch (Exception ex)
             {
@@ -236,7 +337,16 @@ namespace Dx.Domain
 
         #region Recover
 
-        public static Result<T> Recover<T>(this Result<T> result, Func<DomainError, T> recoveryFunc) where T : notnull
+        /// <summary>
+        /// Recovers from a failure by transforming the error into a success value using the specified recovery function.
+        /// </summary>
+        /// <typeparam name="TValue">The type of the value. Must be non-nullable.</typeparam>
+        /// <param name="result">The source result.</param>
+        /// <param name="recoveryFunc">The recovery function that produces a value from the error. Must not be <see langword="null"/>.</param>
+        /// <returns>A success result containing the recovered value if <paramref name="result"/> is a failure; otherwise, the original result.</returns>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="recoveryFunc"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="recoveryFunc"/> throws an exception. The original exception is included as the inner exception.</exception>
+        public static Result<TValue> Recover<TValue>(this Result<TValue> result, Func<DomainError, TValue> recoveryFunc) where TValue : notnull
         {
             Invariant.That(recoveryFunc is not null, "Result.Recover.ParameterCannotBeNull", "The recovery function cannot be null.");
 
@@ -252,7 +362,16 @@ namespace Dx.Domain
             }
         }
 
-        public static Result<T> Recover<T>(this Result<T> result, Func<DomainError, Result<T>> recoveryFunc) where T : notnull
+        /// <summary>
+        /// Recovers from a failure by producing a new result using the specified recovery function.
+        /// </summary>
+        /// <typeparam name="TValue">The type of the value. Must be non-nullable.</typeparam>
+        /// <param name="result">The source result.</param>
+        /// <param name="recoveryFunc">The recovery function that produces a result from the error. Must not be <see langword="null"/>.</param>
+        /// <returns>The result produced by <paramref name="recoveryFunc"/> if <paramref name="result"/> is a failure; otherwise, the original result.</returns>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="recoveryFunc"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="recoveryFunc"/> throws an exception. The original exception is included as the inner exception.</exception>
+        public static Result<TValue> Recover<TValue>(this Result<TValue> result, Func<DomainError, Result<TValue>> recoveryFunc) where TValue : notnull
         {
             Invariant.That(recoveryFunc is not null, "Result.Recover.ParameterCannotBeNull", "The recovery function cannot be null.");
 
@@ -266,7 +385,16 @@ namespace Dx.Domain
             }
         }
 
-        public static async ValueTask<Result<T>> RecoverAsync<T>(this Result<T> result, Func<DomainError, Task<T>> recoveryFunc) where T : notnull
+        /// <summary>
+        /// Recovers from a failure asynchronously by transforming the error into a success value.
+        /// </summary>
+        /// <typeparam name="TValue">The type of the value. Must be non-nullable.</typeparam>
+        /// <param name="result">The source result.</param>
+        /// <param name="recoveryFunc">The asynchronous recovery function that produces a value from the error. Must not be <see langword="null"/>.</param>
+        /// <returns>A value task that represents the asynchronous operation. The result contains the recovered success if applicable.</returns>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="recoveryFunc"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="recoveryFunc"/> throws an exception. The original exception is included as the inner exception.</exception>
+        public static async ValueTask<Result<TValue>> RecoverAsync<TValue>(this Result<TValue> result, Func<DomainError, Task<TValue>> recoveryFunc) where TValue : notnull
         {
             Invariant.That(recoveryFunc is not null, "Result.Recover.ParameterCannotBeNull", "The recovery function cannot be null.");
 
@@ -282,7 +410,16 @@ namespace Dx.Domain
             }
         }
 
-        public static async ValueTask<Result<T>> RecoverAsync<T>(this Result<T> result, Func<DomainError, Task<Result<T>>> recovery) where T : notnull
+        /// <summary>
+        /// Recovers from a failure asynchronously by producing a new result.
+        /// </summary>
+        /// <typeparam name="TValue">The type of the value. Must be non-nullable.</typeparam>
+        /// <param name="result">The source result.</param>
+        /// <param name="recovery">The asynchronous recovery function that produces a result from the error. Must not be <see langword="null"/>.</param>
+        /// <returns>A value task that represents the asynchronous operation. The result contains the recovered result if applicable.</returns>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="recovery"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="recovery"/> throws an exception. The original exception is included as the inner exception.</exception>
+        public static async ValueTask<Result<TValue>> RecoverAsync<TValue>(this Result<TValue> result, Func<DomainError, Task<Result<TValue>>> recovery) where TValue : notnull
         {
             Invariant.That(recovery is not null, "Result.Recover.ParameterCannotBeNull", "The recovery function cannot be null.");
 
@@ -302,8 +439,20 @@ namespace Dx.Domain
 
         #region Match
 
-        public static TOut Match<TOut, T>(this Result<T> result, Func<T, TOut> onSuccess, Func<DomainError, TOut> onFailure)
-            where T : notnull
+        /// <summary>
+        /// Projects a <see cref="Result{TValue}"/> into a value by invoking the appropriate handler.
+        /// </summary>
+        /// <typeparam name="TOut">The type of the projected value. Must be non-nullable.</typeparam>
+        /// <typeparam name="TValue">The type of the value. Must be non-nullable.</typeparam>
+        /// <param name="result">The source result.</param>
+        /// <param name="onSuccess">The handler invoked when <paramref name="result"/> is successful. Must not be <see langword="null"/>.</param>
+        /// <param name="onFailure">The handler invoked when <paramref name="result"/> is a failure. Must not be <see langword="null"/>.</param>
+        /// <returns>The value produced by the invoked handler.</returns>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="onSuccess"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="onFailure"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvariantViolationException">Thrown when either handler throws an exception. The original exception is included as the inner exception.</exception>
+        public static TOut Match<TOut, TValue>(this Result<TValue> result, Func<TValue, TOut> onSuccess, Func<DomainError, TOut> onFailure)
+            where TValue : notnull
             where TOut : notnull
         {
             Invariant.That(onSuccess is not null, "Result.Match.ParameterCannotBeNull", "The onSuccess function cannot be null.");
@@ -321,7 +470,17 @@ namespace Dx.Domain
             }
         }
 
-        public static void Match<T>(this Result<T> result, Action<T> onSuccess, Action<DomainError> onFailure) where T : notnull
+        /// <summary>
+        /// Invokes the appropriate action based on the state of the result.
+        /// </summary>
+        /// <typeparam name="TValue">The type of the value. Must be non-nullable.</typeparam>
+        /// <param name="result">The source result.</param>
+        /// <param name="onSuccess">The action invoked when <paramref name="result"/> is successful. Must not be <see langword="null"/>.</param>
+        /// <param name="onFailure">The action invoked when <paramref name="result"/> is a failure. Must not be <see langword="null"/>.</param>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="onSuccess"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="onFailure"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvariantViolationException">Thrown when either action throws an exception. The original exception is included as the inner exception.</exception>
+        public static void Match<TValue>(this Result<TValue> result, Action<TValue> onSuccess, Action<DomainError> onFailure) where TValue : notnull
         {
             Invariant.That(onSuccess is not null, "Result.Match.ParameterCannotBeNull", "The onSuccess function cannot be null.");
             Invariant.That(onFailure is not null, "Result.Match.ParameterCannotBeNull", "The onFailure function cannot be null.");
@@ -339,7 +498,19 @@ namespace Dx.Domain
             }
         }
 
-        public static async ValueTask<TOut> MatchAsync<T, TOut>(this Result<T> result, Func<T, Task<TOut>> onSuccess, Func<DomainError, Task<TOut>> onFailure) where T : notnull
+        /// <summary>
+        /// Projects a <see cref="Result{TValue}"/> into a value asynchronously by invoking the appropriate handler.
+        /// </summary>
+        /// <typeparam name="TValue">The type of the value. Must be non-nullable.</typeparam>
+        /// <typeparam name="TOut">The type of the projected value. Must be non-nullable.</typeparam>
+        /// <param name="result">The source result.</param>
+        /// <param name="onSuccess">The asynchronous handler invoked when <paramref name="result"/> is successful. Must not be <see langword="null"/>.</param>
+        /// <param name="onFailure">The asynchronous handler invoked when <paramref name="result"/> is a failure. Must not be <see langword="null"/>.</param>
+        /// <returns>A value task that represents the asynchronous operation. The result contains the value produced by the invoked handler.</returns>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="onSuccess"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="onFailure"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvariantViolationException">Thrown when either handler throws an exception. The original exception is included as the inner exception.</exception>
+        public static async ValueTask<TOut> MatchAsync<TValue, TOut>(this Result<TValue> result, Func<TValue, Task<TOut>> onSuccess, Func<DomainError, Task<TOut>> onFailure) where TValue : notnull
         {
             Invariant.That(onSuccess is not null, "Result.Match.ParameterCannotBeNull", "The onSuccess function cannot be null.");
             Invariant.That(onFailure is not null, "Result.Match.ParameterCannotBeNull", "The onFailure function cannot be null.");
@@ -356,7 +527,18 @@ namespace Dx.Domain
             }
         }
 
-        public static async ValueTask MatchAsync<T>(this Result<T> result, Func<T, Task> onSuccess, Func<DomainError, Task> onFailure) where T : notnull
+        /// <summary>
+        /// Invokes the appropriate asynchronous action based on the state of the result.
+        /// </summary>
+        /// <typeparam name="TValue">The type of the value. Must be non-nullable.</typeparam>
+        /// <param name="result">The source result.</param>
+        /// <param name="onSuccess">The asynchronous action invoked when <paramref name="result"/> is successful. Must not be <see langword="null"/>.</param>
+        /// <param name="onFailure">The asynchronous action invoked when <paramref name="result"/> is a failure. Must not be <see langword="null"/>.</param>
+        /// <returns>A value task that represents the asynchronous operation.</returns>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="onSuccess"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="onFailure"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvariantViolationException">Thrown when either action throws an exception. The original exception is included as the inner exception.</exception>
+        public static async ValueTask MatchAsync<TValue>(this Result<TValue> result, Func<TValue, Task> onSuccess, Func<DomainError, Task> onFailure) where TValue : notnull
         {
             Invariant.That(onSuccess is not null, "Result.Match.ParameterCannotBeNull", "The onSuccess function cannot be null.");
             Invariant.That(onFailure is not null, "Result.Match.ParameterCannotBeNull", "The onFailure function cannot be null.");
@@ -378,52 +560,89 @@ namespace Dx.Domain
 
         #region Flatten / Sequence / Traverse
 
-        public static Result<T> Flatten<T>(this Result<Result<T>> result) where T : notnull
+        /// <summary>
+        /// Flattens a nested <see cref="Result{TValue}"/> that contains another <see cref="Result{TValue}"/> into a single-level result.
+        /// </summary>
+        /// <typeparam name="TValue">The type of the value. Must be non-nullable.</typeparam>
+        /// <param name="result">The nested result to flatten.</param>
+        /// <returns>The inner result if <paramref name="result"/> is successful; otherwise, a failure containing the outer error.</returns>
+        public static Result<TValue> Flatten<TValue>(this Result<Result<TValue>> result) where TValue : notnull
             => result.IsFailure
-                ? Result.Failure<T>(result.Error)
+                ? Result.Failure<TValue>(result.Error)
                 : result.Value;
 
-        public static async ValueTask<Result<T>> FlattenAsync<T>(this ValueTask<Result<Result<T>>> resultTask) where T : notnull
+        /// <summary>
+        /// Flattens a nested result asynchronously.
+        /// </summary>
+        /// <typeparam name="TValue">The type of the value. Must be non-nullable.</typeparam>
+        /// <param name="resultTask">The task producing the nested <see cref="Result{TValue}"/>.</param>
+        /// <returns>A value task that represents the asynchronous operation. The result contains the flattened result.</returns>
+        public static async ValueTask<Result<TValue>> FlattenAsync<TValue>(this ValueTask<Result<Result<TValue>>> resultTask) where TValue : notnull
         {
             var result = await resultTask.ConfigureAwait(false);
             return result.IsFailure
-                ? Result.Failure<T>(result.Error)
+                ? Result.Failure<TValue>(result.Error)
                 : result.Value;
         }
 
-        public static Result<IReadOnlyList<T>> Sequence<T>(this IEnumerable<Result<T>> results) where T : notnull
+        /// <summary>
+        /// Converts a sequence of results into a result containing a read-only list, failing fast on the first error.
+        /// </summary>
+        /// <typeparam name="TValue">The type of the values. Must be non-nullable.</typeparam>
+        /// <param name="results">The sequence of results to evaluate. Must not be <see langword="null"/>.</param>
+        /// <returns>A success result containing all values if all results succeed; otherwise, the first encountered failure.</returns>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="results"/> is <see langword="null"/>.</exception>
+        public static Result<IReadOnlyList<TValue>> Sequence<TValue>(this IEnumerable<Result<TValue>> results) where TValue : notnull
         {
             Invariant.That(results is not null, "Result.Sequence.ParameterCannotBeNull", "The results sequence cannot be null.");
 
-            var list = new List<T>();
+            var list = new List<TValue>();
             foreach (var result in results!)
             {
                 if (result.IsFailure)
-                    return Result.Failure<IReadOnlyList<T>>(result.Error);
+                    return Result.Failure<IReadOnlyList<TValue>>(result.Error);
 
                 list.Add(result.Value);
             }
 
-            return Result.Success<IReadOnlyList<T>>(list);
+            return Result.Success<IReadOnlyList<TValue>>(list);
         }
 
-        public static async ValueTask<Result<IReadOnlyList<T>>> SequenceAsync<T>(this IEnumerable<Task<Result<T>>> resultTasks) where T : notnull
+        /// <summary>
+        /// Converts a sequence of result tasks into a result containing a read-only list, failing fast on the first error.
+        /// </summary>
+        /// <typeparam name="TValue">The type of the values. Must be non-nullable.</typeparam>
+        /// <param name="resultTasks">The sequence of result tasks to evaluate. Must not be <see langword="null"/>.</param>
+        /// <returns>A value task that represents the asynchronous operation. The result contains aggregated values or the first failure.</returns>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="resultTasks"/> is <see langword="null"/>.</exception>
+        public static async ValueTask<Result<IReadOnlyList<TValue>>> SequenceAsync<TValue>(this IEnumerable<Task<Result<TValue>>> resultTasks) where TValue : notnull
         {
             Invariant.That(resultTasks is not null, "Result.Sequence.ParameterCannotBeNull", "The results sequence cannot be null.");
 
-            var list = new List<T>();
+            var list = new List<TValue>();
 
             foreach (var resultTask in resultTasks!)
             {
                 var result = await resultTask.ConfigureAwait(false);
                 if (result.IsFailure)
-                    return Result.Failure<IReadOnlyList<T>>(result.Error);
+                    return Result.Failure<IReadOnlyList<TValue>>(result.Error);
                 list.Add(result.Value);
             }
 
-            return Result.Success<IReadOnlyList<T>>(list);
+            return Result.Success<IReadOnlyList<TValue>>(list);
         }
 
+        /// <summary>
+        /// Projects each element of a sequence into a result and aggregates successful values, failing fast on the first error.
+        /// </summary>
+        /// <typeparam name="TIn">The type of the source elements. Must be non-nullable.</typeparam>
+        /// <typeparam name="TOut">The type of the projected values. Must be non-nullable.</typeparam>
+        /// <param name="source">The source sequence. Must not be <see langword="null"/>.</param>
+        /// <param name="selector">The projection function that produces a result for each element. Must not be <see langword="null"/>.</param>
+        /// <returns>A success result containing all projected values if all succeed; otherwise, the first encountered failure.</returns>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="source"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="selector"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="selector"/> throws an exception. The original exception is included as the inner exception.</exception>
         public static Result<IReadOnlyList<TOut>> Traverse<TIn, TOut>(this IEnumerable<TIn> source, Func<TIn, Result<TOut>> selector)
             where TIn : notnull
             where TOut : notnull
@@ -452,6 +671,17 @@ namespace Dx.Domain
             return Result.Success<IReadOnlyList<TOut>>(list);
         }
 
+        /// <summary>
+        /// Projects each element of a sequence into a result asynchronously and aggregates successful values, failing fast on the first error.
+        /// </summary>
+        /// <typeparam name="TIn">The type of the source elements. Must be non-nullable.</typeparam>
+        /// <typeparam name="TOut">The type of the projected values. Must be non-nullable.</typeparam>
+        /// <param name="source">The source sequence. Must not be <see langword="null"/>.</param>
+        /// <param name="selector">The asynchronous projection function that produces a result for each element. Must not be <see langword="null"/>.</param>
+        /// <returns>A value task that represents the asynchronous operation. The result contains aggregated values or the first failure.</returns>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="source"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="selector"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="selector"/> throws an exception. The original exception is included as the inner exception.</exception>
         public static async ValueTask<Result<IReadOnlyList<TOut>>> TraverseAsync<TIn, TOut>(this IEnumerable<TIn> source, Func<TIn, Task<Result<TOut>>> selector)
             where TIn : notnull
             where TOut : notnull
@@ -483,7 +713,16 @@ namespace Dx.Domain
 
         #region Try / Catch / Finally
 
-        public static Result<T> TryCatch<T>(Func<T> func, Func<Exception, DomainError> errorFactory) where T : notnull
+        /// <summary>
+        /// Executes the specified function and captures any thrown exception as a failure result.
+        /// </summary>
+        /// <typeparam name="TValue">The type of the value. Must be non-nullable.</typeparam>
+        /// <param name="func">The function to execute. Must not be <see langword="null"/>.</param>
+        /// <param name="errorFactory">The factory that produces an error from the caught exception. Must not be <see langword="null"/>.</param>
+        /// <returns>A success result containing the function value if no exception occurs; otherwise, a failure result.</returns>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="func"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="errorFactory"/> is <see langword="null"/>.</exception>
+        public static Result<TValue> TryCatch<TValue>(Func<TValue> func, Func<Exception, DomainError> errorFactory) where TValue : notnull
         {
             Invariant.That(func is not null, "Result.TryCatch.ParameterCannotBeNull", "The function cannot be null.");
             Invariant.That(errorFactory is not null, "Result.TryCatch.ParameterCannotBeNull", "The error factory function cannot be null.");
@@ -494,10 +733,19 @@ namespace Dx.Domain
             }
             catch (Exception ex)
             {
-                return Result.Failure<T>(errorFactory!(ex));
+                return Result.Failure<TValue>(errorFactory!(ex));
             }
         }
 
+        /// <summary>
+        /// Executes the specified action and captures any thrown exception as a failure result.
+        /// </summary>
+        /// <param name="action">The action to execute. Must not be <see langword="null"/>.</param>
+        /// <param name="errorFactory">The factory that produces an error from the caught exception. Must not be <see langword="null"/>.</param>
+        /// <returns>A success result containing <see cref="Unit"/> if no exception occurs; otherwise, a failure result.</returns>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="action"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="errorFactory"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="errorFactory"/> throws an exception. The original exception is included as the inner exception.</exception>
         public static Result<Unit> TryCatch(Action action, Func<Exception, DomainError> errorFactory)
         {
             Invariant.That(action is not null, "Result.TryCatch.ParameterCannotBeNull", "The action cannot be null.");
@@ -521,7 +769,17 @@ namespace Dx.Domain
             }
         }
 
-        public static async ValueTask<Result<T>> TryCatchAsync<T>(Func<Task<T>> func, Func<Exception, DomainError> errorFactory) where T : notnull
+        /// <summary>
+        /// Executes the specified asynchronous function and captures any thrown exception as a failure result.
+        /// </summary>
+        /// <typeparam name="TValue">The type of the value. Must be non-nullable.</typeparam>
+        /// <param name="func">The asynchronous function to execute. Must not be <see langword="null"/>.</param>
+        /// <param name="errorFactory">The factory that produces an error from the caught exception. Must not be <see langword="null"/>.</param>
+        /// <returns>A value task that represents the asynchronous operation. The result contains success or captured failure.</returns>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="func"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="errorFactory"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="errorFactory"/> throws an exception. The original exception is included as the inner exception.</exception>
+        public static async ValueTask<Result<TValue>> TryCatchAsync<TValue>(Func<Task<TValue>> func, Func<Exception, DomainError> errorFactory) where TValue : notnull
         {
             Invariant.That(func is not null, "Result.TryCatchAsync.Func.CannotBeNull", "The function to execute cannot be null.");
             Invariant.That(errorFactory is not null, "Result.TryCatchAsync.ErrorFactory.CannotBeNull", "The error factory cannot be null.");
@@ -535,7 +793,7 @@ namespace Dx.Domain
             {
                 try
                 {
-                    return Result.Failure<T>(errorFactory!(ex));
+                    return Result.Failure<TValue>(errorFactory!(ex));
                 }
                 catch (Exception innerEx)
                 {
@@ -544,6 +802,15 @@ namespace Dx.Domain
             }
         }
 
+        /// <summary>
+        /// Executes the specified asynchronous action and captures any thrown exception as a failure result.
+        /// </summary>
+        /// <param name="action">The asynchronous action to execute. Must not be <see langword="null"/>.</param>
+        /// <param name="errorFactory">The factory that produces an error from the caught exception. Must not be <see langword="null"/>.</param>
+        /// <returns>A value task that represents the asynchronous operation. The result contains success or captured failure.</returns>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="action"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="errorFactory"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="errorFactory"/> throws an exception. The original exception is included as the inner exception.</exception>
         public static async ValueTask<Result<Unit>> TryCatchAsync(Func<Task> action, Func<Exception, DomainError> errorFactory)
         {
             Invariant.That(action is not null, "Result.TryCatchAsync.Action.CannotBeNull", "The action to execute cannot be null.");
@@ -571,26 +838,54 @@ namespace Dx.Domain
 
         #region Conversions / Utilities
 
-        public static Task<Result<T>> AsTask<T>(this Result<T> result) where T : notnull
+        /// <summary>
+        /// Wraps the result in a completed <see cref="Task{TResult}"/>.
+        /// </summary>
+        /// <typeparam name="TValue">The type of the value. Must be non-nullable.</typeparam>
+        /// <param name="result">The source result.</param>
+        /// <returns>A completed task containing <paramref name="result"/>.</returns>
+        public static Task<Result<TValue>> AsTask<TValue>(this Result<TValue> result) where TValue : notnull
             => Task.FromResult(result);
 
-        public static ValueTask<Result<T>> AsValueTask<T>(this Result<T> result) where T : notnull
+        /// <summary>
+        /// Wraps the result in a completed <see cref="ValueTask{TResult}"/>.
+        /// </summary>
+        /// <typeparam name="TValue">The type of the value. Must be non-nullable.</typeparam>
+        /// <param name="result">The source result.</param>
+        /// <returns>A completed value task containing <paramref name="result"/>.</returns>
+        public static ValueTask<Result<TValue>> AsValueTask<TValue>(this Result<TValue> result) where TValue : notnull
             => new(result);
 
-        public static Result<T, TError> ToGenericError<T, TError>(this Result<T> result, Func<DomainError, TError> mapError)
-            where T : notnull
+        /// <summary>
+        /// Converts a result using <see cref="DomainError"/> to a result with a generic error type by mapping the error.
+        /// </summary>
+        /// <typeparam name="TValue">The type of the value. Must be non-nullable.</typeparam>
+        /// <typeparam name="TError">The type of the target error. Must be non-nullable.</typeparam>
+        /// <param name="result">The source result.</param>
+        /// <param name="mapError">The function that maps the <see cref="DomainError"/> to <typeparamref name="TError"/>. Must not be <see langword="null"/>.</param>
+        /// <returns>A success result if <paramref name="result"/> is successful; otherwise, a failure containing the mapped error.</returns>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="mapError"/> is <see langword="null"/>.</exception>
+        public static Result<TValue, TError> ToGenericError<TValue, TError>(this Result<TValue> result, Func<DomainError, TError> mapError)
+            where TValue : notnull
             where TError : notnull
         {
             Invariant.That(mapError is not null, "Result.MapError.MapErrorCannotBeNull", "The error mapping function cannot be null.");
 
             if (result.IsSuccess)
-                return Result.Success<T, TError>(result.Value);
+                return Result.Success<TValue, TError>(result.Value);
 
             var mappedError = mapError!(result.Error);
-            return Result.Failure<T, TError>(mappedError);
+            return Result.Failure<TValue, TError>(mappedError);
         }
 
-        public static T Unwrap<T>(this Result<T> result) where T : notnull
+        /// <summary>
+        /// Returns the success value of the result, throwing if the result is a failure.
+        /// </summary>
+        /// <typeparam name="TValue">The type of the value. Must be non-nullable.</typeparam>
+        /// <param name="result">The source result.</param>
+        /// <returns>The success value contained in <paramref name="result"/>.</returns>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="result"/> is in a failure state.</exception>
+        public static TValue Unwrap<TValue>(this Result<TValue> result) where TValue : notnull
         {
             if (result.IsFailure)
             {

--- a/src/Dx.Domain.Kernel/ResultExtensionsGeneric.cs
+++ b/src/Dx.Domain.Kernel/ResultExtensionsGeneric.cs
@@ -28,6 +28,16 @@ namespace Dx.Domain
     {
         #region Map
 
+        /// <summary>
+        /// Transforms the success value of a <see cref="Result{TIn, TError}"/> using the specified mapping function.
+        /// </summary>
+        /// <typeparam name="TIn">The type of the source value. Must be non-nullable.</typeparam>
+        /// <typeparam name="TOut">The type of the mapped value. Must be non-nullable.</typeparam>
+        /// <typeparam name="TError">The type of the error. Must be non-nullable.</typeparam>
+        /// <param name="result">The source result.</param>
+        /// <param name="map">The mapping function to apply to the success value. Must not be <see langword="null"/>.</param>
+        /// <returns>A new <see cref="Result{TOut, TError}"/> containing the mapped value if <paramref name="result"/> is successful; otherwise, a failure result containing the original error.</returns>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="map"/> is <see langword="null"/>.</exception>
         public static Result<TOut, TError> Map<TIn, TOut, TError>(this Result<TIn, TError> result, Func<TIn, TOut> map)
             where TIn : notnull
             where TOut : notnull
@@ -41,6 +51,17 @@ namespace Dx.Domain
             return Result.Success<TOut, TError>(map!(result.Value));
         }
 
+        /// <summary>
+        /// Transforms the success value of a <see cref="Result{TIn, TError}"/> asynchronously using the specified mapping function.
+        /// </summary>
+        /// <typeparam name="TIn">The type of the source value. Must be non-nullable.</typeparam>
+        /// <typeparam name="TOut">The type of the mapped value. Must be non-nullable.</typeparam>
+        /// <typeparam name="TError">The type of the error. Must be non-nullable.</typeparam>
+        /// <param name="result">The source result.</param>
+        /// <param name="map">The asynchronous mapping function to apply to the success value. Must not be <see langword="null"/>.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains a new <see cref="Result{TOut, TError}"/> with the mapped value if successful; otherwise, the original error.</returns>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="map"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="map"/> throws an exception. The original exception is included as the inner exception.</exception>
         public static async Task<Result<TOut, TError>> MapAsync<TIn, TOut, TError>(this Result<TIn, TError> result, Func<TIn, Task<TOut>> map)
             where TIn : notnull
             where TOut : notnull
@@ -69,6 +90,17 @@ namespace Dx.Domain
 
         #region Bind
 
+        /// <summary>
+        /// Binds the success value of a <see cref="Result{TIn, TError}"/> to a new result using the specified binding function.
+        /// </summary>
+        /// <typeparam name="TIn">The type of the source value. Must be non-nullable.</typeparam>
+        /// <typeparam name="TOut">The type of the bound value. Must be non-nullable.</typeparam>
+        /// <typeparam name="TError">The type of the error. Must be non-nullable.</typeparam>
+        /// <param name="result">The source result.</param>
+        /// <param name="bind">The binding function to apply to the success value. Must not be <see langword="null"/>.</param>
+        /// <returns>The result produced by <paramref name="bind"/> if <paramref name="result"/> is successful; otherwise, a failure result containing the original error.</returns>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="bind"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="bind"/> throws an exception. The original exception is included as the inner exception.</exception>
         public static Result<TOut, TError> Bind<TIn, TOut, TError>(this Result<TIn, TError> result, Func<TIn, Result<TOut, TError>> bind)
             where TIn : notnull
             where TOut : notnull
@@ -92,6 +124,17 @@ namespace Dx.Domain
             }
         }
 
+        /// <summary>
+        /// Binds the success value of a <see cref="Result{TIn, TError}"/> to a new result asynchronously using the specified binding function.
+        /// </summary>
+        /// <typeparam name="TIn">The type of the source value. Must be non-nullable.</typeparam>
+        /// <typeparam name="TOut">The type of the bound value. Must be non-nullable.</typeparam>
+        /// <typeparam name="TError">The type of the error. Must be non-nullable.</typeparam>
+        /// <param name="result">The source result.</param>
+        /// <param name="bind">The asynchronous binding function to apply to the success value. Must not be <see langword="null"/>.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains the bound result if successful; otherwise, the original error.</returns>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="bind"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="bind"/> throws an exception. The original exception is included as the inner exception.</exception>
         public static async Task<Result<TOut, TError>> BindAsync<TIn, TOut, TError>(this Result<TIn, TError> result, Func<TIn, Task<Result<TOut, TError>>> bind)
             where TIn : notnull
             where TOut : notnull
@@ -119,8 +162,18 @@ namespace Dx.Domain
 
         #region Tap
 
-        public static Result<T, TError> Tap<T, TError>(this Result<T, TError> result, Action<T> action)
-            where T : notnull
+        /// <summary>
+        /// Executes the specified action if the result is successful, returning the original result unchanged.
+        /// </summary>
+        /// <typeparam name="TValue">The type of the value. Must be non-nullable.</typeparam>
+        /// <typeparam name="TError">The type of the error. Must be non-nullable.</typeparam>
+        /// <param name="result">The source result.</param>
+        /// <param name="action">The action to execute on the success value. Must not be <see langword="null"/>.</param>
+        /// <returns>The original <paramref name="result"/>.</returns>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="action"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="action"/> throws an exception. The original exception is included as the inner exception.</exception>
+        public static Result<TValue, TError> Tap<TValue, TError>(this Result<TValue, TError> result, Action<TValue> action)
+            where TValue : notnull
             where TError : notnull
         {
             Invariant.That(action is not null, "Result.Tap.ParameterCannotBeNull", "The tap action cannot be null.");
@@ -142,8 +195,18 @@ namespace Dx.Domain
             }
         }
 
-        public static async Task<Result<T, TError>> TapAsync<T, TError>(this Result<T, TError> result, Func<T, Task> action)
-            where T : notnull
+        /// <summary>
+        /// Executes the specified asynchronous action if the result is successful, returning the original result unchanged.
+        /// </summary>
+        /// <typeparam name="TValue">The type of the value. Must be non-nullable.</typeparam>
+        /// <typeparam name="TError">The type of the error. Must be non-nullable.</typeparam>
+        /// <param name="result">The source result.</param>
+        /// <param name="action">The asynchronous action to execute on the success value. Must not be <see langword="null"/>.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains the original <paramref name="result"/>.</returns>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="action"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="action"/> throws an exception. The original exception is included as the inner exception.</exception>
+        public static async Task<Result<TValue, TError>> TapAsync<TValue, TError>(this Result<TValue, TError> result, Func<TValue, Task> action)
+            where TValue : notnull
             where TError : notnull
         {
             Invariant.That(action is not null, "Result.TapAsync.ParameterCannotBeNull", "The tap action cannot be null.");
@@ -169,8 +232,19 @@ namespace Dx.Domain
 
         #region Ensure / Validate
 
-        public static Result<T, TError> Ensure<T, TError>(this Result<T, TError> result, Func<T, bool> predicate, TError error)
-            where T : notnull
+        /// <summary>
+        /// Ensures the success value satisfies the specified predicate, otherwise returns a failure with the provided error.
+        /// </summary>
+        /// <typeparam name="TValue">The type of the value. Must be non-nullable.</typeparam>
+        /// <typeparam name="TError">The type of the error. Must be non-nullable.</typeparam>
+        /// <param name="result">The source result.</param>
+        /// <param name="predicate">The predicate to evaluate against the success value. Must not be <see langword="null"/>.</param>
+        /// <param name="error">The error to return if <paramref name="predicate"/> returns <see langword="false"/>.</param>
+        /// <returns>The original result if the predicate is satisfied; otherwise, a failure result containing <paramref name="error"/>.</returns>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="predicate"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="predicate"/> throws an exception. The original exception is included as the inner exception.</exception>
+        public static Result<TValue, TError> Ensure<TValue, TError>(this Result<TValue, TError> result, Func<TValue, bool> predicate, TError error)
+            where TValue : notnull
             where TError : notnull
         {
             Invariant.That(predicate is not null, "Result.Ensure.ParameterCannotBeNull", "The predicate cannot be null.");
@@ -180,7 +254,7 @@ namespace Dx.Domain
 
             try
             {
-                return predicate!(result.Value) ? result : Result.Failure<T, TError>(error);
+                return predicate!(result.Value) ? result : Result.Failure<TValue, TError>(error);
             }
             catch (Exception ex)
             {
@@ -191,8 +265,20 @@ namespace Dx.Domain
             }
         }
 
-        public static Result<T, TError> Ensure<T, TError>(this Result<T, TError> result, Func<T, bool> predicate, Func<TError> errorFactory)
-            where T : notnull
+        /// <summary>
+        /// Ensures the success value satisfies the specified predicate, otherwise returns a failure with an error produced by the factory.
+        /// </summary>
+        /// <typeparam name="TValue">The type of the value. Must be non-nullable.</typeparam>
+        /// <typeparam name="TError">The type of the error. Must be non-nullable.</typeparam>
+        /// <param name="result">The source result.</param>
+        /// <param name="predicate">The predicate to evaluate against the success value. Must not be <see langword="null"/>.</param>
+        /// <param name="errorFactory">The factory function that produces the error when the predicate fails. Must not be <see langword="null"/>.</param>
+        /// <returns>The original result if the predicate is satisfied; otherwise, a failure result containing the produced error.</returns>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="predicate"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="errorFactory"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="predicate"/> throws an exception. The original exception is included as the inner exception.</exception>
+        public static Result<TValue, TError> Ensure<TValue, TError>(this Result<TValue, TError> result, Func<TValue, bool> predicate, Func<TError> errorFactory)
+            where TValue : notnull
             where TError : notnull
         {
             Invariant.That(predicate is not null, "Result.Ensure.ParameterCannotBeNull", "The predicate cannot be null.");
@@ -203,7 +289,7 @@ namespace Dx.Domain
 
             try
             {
-                return predicate!(result.Value) ? result : Result.Failure<T, TError>(errorFactory!());
+                return predicate!(result.Value) ? result : Result.Failure<TValue, TError>(errorFactory!());
             }
             catch (Exception ex)
             {
@@ -214,8 +300,19 @@ namespace Dx.Domain
             }
         }
 
-        public static async Task<Result<T, TError>> EnsureAsync<T, TError>(this Result<T, TError> result, Func<T, Task<bool>> predicate, TError error)
-            where T : notnull
+        /// <summary>
+        /// Ensures the success value satisfies the specified asynchronous predicate, otherwise returns a failure with the provided error.
+        /// </summary>
+        /// <typeparam name="TValue">The type of the value. Must be non-nullable.</typeparam>
+        /// <typeparam name="TError">The type of the error. Must be non-nullable.</typeparam>
+        /// <param name="result">The source result.</param>
+        /// <param name="predicate">The asynchronous predicate to evaluate against the success value. Must not be <see langword="null"/>.</param>
+        /// <param name="error">The error to return if <paramref name="predicate"/> returns <see langword="false"/>.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains the original result if satisfied; otherwise, a failure.</returns>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="predicate"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="predicate"/> throws an exception. The original exception is included as the inner exception.</exception>
+        public static async Task<Result<TValue, TError>> EnsureAsync<TValue, TError>(this Result<TValue, TError> result, Func<TValue, Task<bool>> predicate, TError error)
+            where TValue : notnull
             where TError : notnull
         {
             Invariant.That(predicate is not null, "Result.Ensure.ParameterCannotBeNull", "The predicate cannot be null.");
@@ -227,7 +324,7 @@ namespace Dx.Domain
             {
                 return await predicate!(result.Value).ConfigureAwait(false)
                     ? result
-                    : Result.Failure<T, TError>(error);
+                    : Result.Failure<TValue, TError>(error);
             }
             catch (Exception ex)
             {
@@ -238,8 +335,20 @@ namespace Dx.Domain
             }
         }
 
-        public static async Task<Result<T, TError>> EnsureAsync<T, TError>(this Result<T, TError> result, Func<T, Task<bool>> predicate, Func<Task<TError>> errorFactory)
-            where T : notnull
+        /// <summary>
+        /// Ensures the success value satisfies the specified asynchronous predicate, otherwise returns a failure with an error produced asynchronously.
+        /// </summary>
+        /// <typeparam name="TValue">The type of the value. Must be non-nullable.</typeparam>
+        /// <typeparam name="TError">The type of the error. Must be non-nullable.</typeparam>
+        /// <param name="result">The source result.</param>
+        /// <param name="predicate">The asynchronous predicate to evaluate against the success value. Must not be <see langword="null"/>.</param>
+        /// <param name="errorFactory">The asynchronous factory that produces the error when the predicate fails. Must not be <see langword="null"/>.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains the original result if satisfied; otherwise, a failure.</returns>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="predicate"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="errorFactory"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="predicate"/> throws an exception. The original exception is included as the inner exception.</exception>
+        public static async Task<Result<TValue, TError>> EnsureAsync<TValue, TError>(this Result<TValue, TError> result, Func<TValue, Task<bool>> predicate, Func<Task<TError>> errorFactory)
+            where TValue : notnull
             where TError : notnull
         {
             Invariant.That(predicate is not null, "Result.Ensure.ParameterCannotBeNull", "The predicate cannot be null.");
@@ -252,7 +361,7 @@ namespace Dx.Domain
             {
                 return await predicate!(result.Value).ConfigureAwait(false)
                     ? result
-                    : Result.Failure<T, TError>(await errorFactory!().ConfigureAwait(false));
+                    : Result.Failure<TValue, TError>(await errorFactory!().ConfigureAwait(false));
             }
             catch (Exception ex)
             {
@@ -267,8 +376,18 @@ namespace Dx.Domain
 
         #region Recover / Fallback
 
-        public static Result<T, TError> Recover<T, TError>(this Result<T, TError> result, Func<TError, T> recovery)
-            where T : notnull
+        /// <summary>
+        /// Recovers from a failure by transforming the error into a success value using the specified recovery function.
+        /// </summary>
+        /// <typeparam name="TValue">The type of the value. Must be non-nullable.</typeparam>
+        /// <typeparam name="TError">The type of the error. Must be non-nullable.</typeparam>
+        /// <param name="result">The source result.</param>
+        /// <param name="recovery">The recovery function that produces a value from the error. Must not be <see langword="null"/>.</param>
+        /// <returns>A success result containing the recovered value if <paramref name="result"/> is a failure; otherwise, the original result.</returns>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="recovery"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="recovery"/> throws an exception. The original exception is included as the inner exception.</exception>
+        public static Result<TValue, TError> Recover<TValue, TError>(this Result<TValue, TError> result, Func<TError, TValue> recovery)
+            where TValue : notnull
             where TError : notnull
         {
             Invariant.That(recovery is not null, "Result.Recover.ParameterCannotBeNull", "The recovery function cannot be null.");
@@ -276,12 +395,11 @@ namespace Dx.Domain
             try
             {
                 return result.IsFailure
-                    ? Result.Success<T, TError>(recovery!(result.Error))
+                    ? Result.Success<TValue, TError>(recovery!(result.Error))
                     : result;
             }
             catch (Exception ex)
             {
-                // return Result.Failure<T, TError>(...) would hide the original exception
                 throw InvariantViolationException.Create(
                     "Result.Recover.RecoveryFunctionThrewException",
                     "An error occurred while executing the recovery function.",
@@ -289,8 +407,18 @@ namespace Dx.Domain
             }
         }
 
-        public static Result<T, TError> Recover<T, TError>(this Result<T, TError> result, Func<TError, Result<T, TError>> recovery)
-            where T : notnull
+        /// <summary>
+        /// Recovers from a failure by producing a new result using the specified recovery function.
+        /// </summary>
+        /// <typeparam name="TValue">The type of the value. Must be non-nullable.</typeparam>
+        /// <typeparam name="TError">The type of the error. Must be non-nullable.</typeparam>
+        /// <param name="result">The source result.</param>
+        /// <param name="recovery">The recovery function that produces a result from the error. Must not be <see langword="null"/>.</param>
+        /// <returns>The result produced by <paramref name="recovery"/> if <paramref name="result"/> is a failure; otherwise, the original result.</returns>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="recovery"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="recovery"/> throws an exception. The original exception is included as the inner exception.</exception>
+        public static Result<TValue, TError> Recover<TValue, TError>(this Result<TValue, TError> result, Func<TError, Result<TValue, TError>> recovery)
+            where TValue : notnull
             where TError : notnull
         {
             Invariant.That(recovery is not null, "Result.Recover.ParameterCannotBeNull", "The recovery function cannot be null.");
@@ -301,7 +429,6 @@ namespace Dx.Domain
             }
             catch (Exception ex)
             {
-                // return Result.Failure<T, TError>(...) would hide the original exception
                 throw InvariantViolationException.Create(
                     "Result.Recover.RecoveryFunctionThrewException",
                     "An error occurred while executing the recovery function.",
@@ -309,8 +436,18 @@ namespace Dx.Domain
             }
         }
 
-        public static async Task<Result<T, TError>> RecoverAsync<T, TError>(this Result<T, TError> result, Func<TError, Task<T>> recovery)
-            where T : notnull
+        /// <summary>
+        /// Recovers from a failure asynchronously by transforming the error into a success value.
+        /// </summary>
+        /// <typeparam name="TValue">The type of the value. Must be non-nullable.</typeparam>
+        /// <typeparam name="TError">The type of the error. Must be non-nullable.</typeparam>
+        /// <param name="result">The source result.</param>
+        /// <param name="recovery">The asynchronous recovery function that produces a value from the error. Must not be <see langword="null"/>.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains the recovered success if applicable.</returns>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="recovery"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="recovery"/> throws an exception. The original exception is included as the inner exception.</exception>
+        public static async Task<Result<TValue, TError>> RecoverAsync<TValue, TError>(this Result<TValue, TError> result, Func<TError, Task<TValue>> recovery)
+            where TValue : notnull
             where TError : notnull
         {
             Invariant.That(recovery is not null, "Result.Recover.ParameterCannotBeNull", "The recovery function cannot be null.");
@@ -318,12 +455,11 @@ namespace Dx.Domain
             try
             {
                 return result.IsFailure
-                    ? Result.Success<T, TError>(await recovery!(result.Error).ConfigureAwait(false))
+                    ? Result.Success<TValue, TError>(await recovery!(result.Error).ConfigureAwait(false))
                     : result;
             }
             catch (Exception ex)
             {
-                // return Result.Failure<T, TError>(...) would hide the original exception
                 throw InvariantViolationException.Create(
                     "Result.Recover.RecoveryFunctionThrewException",
                     "An error occurred while executing the recovery function.",
@@ -331,8 +467,18 @@ namespace Dx.Domain
             }
         }
 
-        public static async Task<Result<T, TError>> RecoverAsync<T, TError>(this Result<T, TError> result, Func<TError, Task<Result<T, TError>>> recovery)
-            where T : notnull
+        /// <summary>
+        /// Recovers from a failure asynchronously by producing a new result.
+        /// </summary>
+        /// <typeparam name="TValue">The type of the value. Must be non-nullable.</typeparam>
+        /// <typeparam name="TError">The type of the error. Must be non-nullable.</typeparam>
+        /// <param name="result">The source result.</param>
+        /// <param name="recovery">The asynchronous recovery function that produces a result from the error. Must not be <see langword="null"/>.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains the recovered result if applicable.</returns>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="recovery"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="recovery"/> throws an exception. The original exception is included as the inner exception.</exception>
+        public static async Task<Result<TValue, TError>> RecoverAsync<TValue, TError>(this Result<TValue, TError> result, Func<TError, Task<Result<TValue, TError>>> recovery)
+            where TValue : notnull
             where TError : notnull
         {
             Invariant.That(recovery is not null, "Result.Recover.ParameterCannotBeNull", "The recovery function cannot be null.");
@@ -345,7 +491,6 @@ namespace Dx.Domain
             }
             catch (Exception ex)
             {
-                // return Result.Failure<T, TError>(...) would hide the original exception
                 throw InvariantViolationException.Create(
                     "Result.Recover.RecoveryFunctionThrewException",
                     "An error occurred while executing the recovery function.",
@@ -357,8 +502,21 @@ namespace Dx.Domain
 
         #region Match / Observers
 
-        public static TOut Match<T, TError, TOut>(this Result<T, TError> result, Func<T, TOut> onSuccess, Func<TError, TOut> onFailure)
-            where T : notnull
+        /// <summary>
+        /// Projects a <see cref="Result{TValue, TError}"/> into a value by invoking the appropriate handler.
+        /// </summary>
+        /// <typeparam name="TValue">The type of the value. Must be non-nullable.</typeparam>
+        /// <typeparam name="TError">The type of the error. Must be non-nullable.</typeparam>
+        /// <typeparam name="TOut">The type of the projected value. Must be non-nullable.</typeparam>
+        /// <param name="result">The source result.</param>
+        /// <param name="onSuccess">The handler invoked when <paramref name="result"/> is successful. Must not be <see langword="null"/>.</param>
+        /// <param name="onFailure">The handler invoked when <paramref name="result"/> is a failure. Must not be <see langword="null"/>.</param>
+        /// <returns>The value produced by the invoked handler.</returns>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="onSuccess"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="onFailure"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvariantViolationException">Thrown when either handler throws an exception. The original exception is included as the inner exception.</exception>
+        public static TOut Match<TValue, TError, TOut>(this Result<TValue, TError> result, Func<TValue, TOut> onSuccess, Func<TError, TOut> onFailure)
+            where TValue : notnull
             where TError : notnull
             where TOut : notnull
         {
@@ -380,8 +538,19 @@ namespace Dx.Domain
             }
         }
 
-        public static void Match<T, TError>(this Result<T, TError> result, Action<T> onSuccess, Action<TError> onFailure)
-            where T : notnull
+        /// <summary>
+        /// Invokes the appropriate action based on the state of the result.
+        /// </summary>
+        /// <typeparam name="TValue">The type of the value. Must be non-nullable.</typeparam>
+        /// <typeparam name="TError">The type of the error. Must be non-nullable.</typeparam>
+        /// <param name="result">The source result.</param>
+        /// <param name="onSuccess">The action invoked when <paramref name="result"/> is successful. Must not be <see langword="null"/>.</param>
+        /// <param name="onFailure">The action invoked when <paramref name="result"/> is a failure. Must not be <see langword="null"/>.</param>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="onSuccess"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="onFailure"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvariantViolationException">Thrown when either action throws an exception. The original exception is included as the inner exception.</exception>
+        public static void Match<TValue, TError>(this Result<TValue, TError> result, Action<TValue> onSuccess, Action<TError> onFailure)
+            where TValue : notnull
             where TError : notnull
         {
             Invariant.That(onSuccess is not null, "Result.Match.ParameterCannotBeNull", "The onSuccess function cannot be null.");
@@ -403,8 +572,21 @@ namespace Dx.Domain
             }
         }
 
-        public static async Task<TOut> MatchAsync<T, TError, TOut>(this Result<T, TError> result, Func<T, Task<TOut>> onSuccess, Func<TError, Task<TOut>> onFailure)
-            where T : notnull
+        /// <summary>
+        /// Projects a <see cref="Result{T, TError}"/> into a value asynchronously by invoking the appropriate handler.
+        /// </summary>
+        /// <typeparam name="TValue">The type of the value. Must be non-nullable.</typeparam>
+        /// <typeparam name="TError">The type of the error. Must be non-nullable.</typeparam>
+        /// <typeparam name="TOut">The type of the projected value. Must be non-nullable.</typeparam>
+        /// <param name="result">The source result.</param>
+        /// <param name="onSuccess">The asynchronous handler invoked when <paramref name="result"/> is successful. Must not be <see langword="null"/>.</param>
+        /// <param name="onFailure">The asynchronous handler invoked when <paramref name="result"/> is a failure. Must not be <see langword="null"/>.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains the value produced by the invoked handler.</returns>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="onSuccess"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="onFailure"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvariantViolationException">Thrown when either handler throws an exception. The original exception is included as the inner exception.</exception>
+        public static async Task<TOut> MatchAsync<TValue, TError, TOut>(this Result<TValue, TError> result, Func<TValue, Task<TOut>> onSuccess, Func<TError, Task<TOut>> onFailure)
+            where TValue : notnull
             where TError : notnull
             where TOut : notnull
         {
@@ -426,8 +608,20 @@ namespace Dx.Domain
             }
         }
 
-        public static async Task MatchAsync<T, TError>(this Result<T, TError> result, Func<T, Task> onSuccess, Func<TError, Task> onFailure)
-            where T : notnull
+        /// <summary>
+        /// Invokes the appropriate asynchronous action based on the state of the result.
+        /// </summary>
+        /// <typeparam name="TValue">The type of the value. Must be non-nullable.</typeparam>
+        /// <typeparam name="TError">The type of the error. Must be non-nullable.</typeparam>
+        /// <param name="result">The source result.</param>
+        /// <param name="onSuccess">The asynchronous action invoked when <paramref name="result"/> is successful. Must not be <see langword="null"/>.</param>
+        /// <param name="onFailure">The asynchronous action invoked when <paramref name="result"/> is a failure. Must not be <see langword="null"/>.</param>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="onSuccess"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="onFailure"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvariantViolationException">Thrown when either action throws an exception. The original exception is included as the inner exception.</exception>
+        public static async Task MatchAsync<TValue, TError>(this Result<TValue, TError> result, Func<TValue, Task> onSuccess, Func<TError, Task> onFailure)
+            where TValue : notnull
             where TError : notnull
         {
             Invariant.That(onSuccess is not null, "Result.Match.ParameterCannotBeNull", "The onSuccess function cannot be null.");
@@ -453,29 +647,56 @@ namespace Dx.Domain
 
         #region Flatten / Sequence / Traverse
 
-        public static Result<T, TError> Flatten<T, TError>(this Result<Result<T, TError>, TError> result)
-            where T : notnull
+        /// <summary>
+        /// Flattens a nested <see cref="Result{TValue, TError}"/> into a single-level result.
+        /// </summary>
+        /// <typeparam name="TValue">The type of the value. Must be non-nullable.</typeparam>
+        /// <typeparam name="TError">The type of the error. Must be non-nullable.</typeparam>
+        /// <param name="result">The nested result to flatten.</param>
+        /// <returns>The inner result if <paramref name="result"/> is successful; otherwise, a failure containing the outer error.</returns>
+        public static Result<TValue, TError> Flatten<TValue, TError>(this Result<Result<TValue, TError>, TError> result)
+            where TValue : notnull
             where TError : notnull
-            => result.IsFailure ? Result.Failure<T, TError>(result.Error) : result.Value;
+            => result.IsFailure ? Result.Failure<TValue, TError>(result.Error) : result.Value;
 
-        public static Result<IReadOnlyList<T>, TError> Sequence<T, TError>(this IEnumerable<Result<T, TError>> results)
-            where T : notnull
+        /// <summary>
+        /// Converts a sequence of results into a result containing a read-only list, failing fast on the first error.
+        /// </summary>
+        /// <typeparam name="TValue">The type of the values. Must be non-nullable.</typeparam>
+        /// <typeparam name="TError">The type of the error. Must be non-nullable.</typeparam>
+        /// <param name="results">The sequence of results to evaluate. Must not be <see langword="null"/>.</param>
+        /// <returns>A success result containing all values if all results succeed; otherwise, the first encountered failure.</returns>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="results"/> is <see langword="null"/>.</exception>
+        public static Result<IReadOnlyList<TValue>, TError> Sequence<TValue, TError>(this IEnumerable<Result<TValue, TError>> results)
+            where TValue : notnull
             where TError : notnull
         {
             Invariant.That(results is not null, "Result.Sequence.ParameterCannotBeNull", "The results sequence cannot be null.");
 
-            var list = new List<T>();
+            var list = new List<TValue>();
             foreach (var r in results!)
             {
                 if (r.IsFailure)
-                    return Result.Failure<IReadOnlyList<T>, TError>(r.Error);
+                    return Result.Failure<IReadOnlyList<TValue>, TError>(r.Error);
 
                 list.Add(r.Value);
             }
 
-            return Result.Success<IReadOnlyList<T>, TError>(list);
+            return Result.Success<IReadOnlyList<TValue>, TError>(list);
         }
 
+        /// <summary>
+        /// Projects each element of a sequence into a result and aggregates successful values, failing fast on the first error.
+        /// </summary>
+        /// <typeparam name="TIn">The type of the source elements. Must be non-nullable.</typeparam>
+        /// <typeparam name="TOut">The type of the projected values. Must be non-nullable.</typeparam>
+        /// <typeparam name="TError">The type of the error. Must be non-nullable.</typeparam>
+        /// <param name="source">The source sequence. Must not be <see langword="null"/>.</param>
+        /// <param name="selector">The projection function that produces a result for each element. Must not be <see langword="null"/>.</param>
+        /// <returns>A success result containing all projected values if all succeed; otherwise, the first encountered failure.</returns>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="source"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="selector"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="selector"/> throws an exception. The original exception is included as the inner exception.</exception>
         public static Result<IReadOnlyList<TOut>, TError> Traverse<TIn, TOut, TError>(this IEnumerable<TIn> source, Func<TIn, Result<TOut, TError>> selector)
             where TIn : notnull
             where TOut : notnull
@@ -507,6 +728,18 @@ namespace Dx.Domain
             return Result.Success<IReadOnlyList<TOut>, TError>(list);
         }
 
+        /// <summary>
+        /// Projects each element of a sequence into a result asynchronously and aggregates successful values, failing fast on the first error.
+        /// </summary>
+        /// <typeparam name="TIn">The type of the source elements. Must be non-nullable.</typeparam>
+        /// <typeparam name="TOut">The type of the projected values. Must be non-nullable.</typeparam>
+        /// <typeparam name="TError">The type of the error. Must be non-nullable.</typeparam>
+        /// <param name="source">The source sequence. Must not be <see langword="null"/>.</param>
+        /// <param name="selector">The asynchronous projection function that produces a result for each element. Must not be <see langword="null"/>.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains aggregated values or the first failure.</returns>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="source"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="selector"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="selector"/> throws an exception. The original exception is included as the inner exception.</exception>
         public static async Task<Result<IReadOnlyList<TOut>, TError>> TraverseAsync<TIn, TOut, TError>(this IEnumerable<TIn> source, Func<TIn, Task<Result<TOut, TError>>> selector)
             where TIn : notnull
             where TOut : notnull
@@ -542,8 +775,18 @@ namespace Dx.Domain
 
         #region Try/Catch helpers
 
-        public static Result<T, TError> TryCatch<T, TError>(Func<T> func, Func<Exception, TError> errorFactory)
-            where T : notnull
+        /// <summary>
+        /// Executes the specified function and captures any thrown exception as a failure result.
+        /// </summary>
+        /// <typeparam name="TValue">The type of the value. Must be non-nullable.</typeparam>
+        /// <typeparam name="TError">The type of the error. Must be non-nullable.</typeparam>
+        /// <param name="func">The function to execute. Must not be <see langword="null"/>.</param>
+        /// <param name="errorFactory">The factory that produces an error from the caught exception. Must not be <see langword="null"/>.</param>
+        /// <returns>A success result containing the function value if no exception occurs; otherwise, a failure result.</returns>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="func"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="errorFactory"/> is <see langword="null"/>.</exception>
+        public static Result<TValue, TError> TryCatch<TValue, TError>(Func<TValue> func, Func<Exception, TError> errorFactory)
+            where TValue : notnull
             where TError : notnull
         {
             Invariant.That(func is not null, "Result.TryCatch.ParameterCannotBeNull", "The function cannot be null.");
@@ -552,6 +795,15 @@ namespace Dx.Domain
             return TrySucceed(func!, errorFactory!);
         }
 
+        /// <summary>
+        /// Executes the specified action and captures any thrown exception as a failure result.
+        /// </summary>
+        /// <typeparam name="TError">The type of the error. Must be non-nullable.</typeparam>
+        /// <param name="action">The action to execute. Must not be <see langword="null"/>.</param>
+        /// <param name="errorFactory">The factory that produces an error from the caught exception. Must not be <see langword="null"/>.</param>
+        /// <returns>A success result containing <see cref="Unit"/> if no exception occurs; otherwise, a failure result.</returns>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="action"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="errorFactory"/> is <see langword="null"/>.</exception>
         public static Result<Unit, TError> TryCatch<TError>(Action action, Func<Exception, TError> errorFactory)
             where TError : notnull
         {
@@ -567,8 +819,18 @@ namespace Dx.Domain
                 errorFactory!);
         }
 
-        public static async Task<Result<T, TError>> TryCatchAsync<T, TError>(Func<Task<T>> func, Func<Exception, TError> errorFactory)
-            where T : notnull
+        /// <summary>
+        /// Executes the specified asynchronous function and captures any thrown exception as a failure result.
+        /// </summary>
+        /// <typeparam name="TValue">The type of the value. Must be non-nullable.</typeparam>
+        /// <typeparam name="TError">The type of the error. Must be non-nullable.</typeparam>
+        /// <param name="func">The asynchronous function to execute. Must not be <see langword="null"/>.</param>
+        /// <param name="errorFactory">The factory that produces an error from the caught exception. Must not be <see langword="null"/>.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains success or captured failure.</returns>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="func"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="errorFactory"/> is <see langword="null"/>.</exception>
+        public static async Task<Result<TValue, TError>> TryCatchAsync<TValue, TError>(Func<Task<TValue>> func, Func<Exception, TError> errorFactory)
+            where TValue : notnull
             where TError : notnull
         {
             Invariant.That(func is not null, "Result.TryCatchAsync.Func.CannotBeNull", "The function to execute cannot be null.");
@@ -577,6 +839,15 @@ namespace Dx.Domain
             return await TrySucceedAsync(func!, errorFactory!).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Executes the specified asynchronous action and captures any thrown exception as a failure result.
+        /// </summary>
+        /// <typeparam name="TError">The type of the error. Must be non-nullable.</typeparam>
+        /// <param name="action">The asynchronous action to execute. Must not be <see langword="null"/>.</param>
+        /// <param name="errorFactory">The factory that produces an error from the caught exception. Must not be <see langword="null"/>.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains success or captured failure.</returns>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="action"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="errorFactory"/> is <see langword="null"/>.</exception>
         public static async Task<Result<Unit, TError>> TryCatchAsync<TError>(Func<Task> action, Func<Exception, TError> errorFactory)
             where TError : notnull
         {
@@ -596,8 +867,16 @@ namespace Dx.Domain
 
         #region Conversions / Utilities
 
-        public static T Unwrap<T, TError>(this Result<T, TError> result)
-            where T : notnull
+        /// <summary>
+        /// Returns the success value of the result, throwing if the result is a failure.
+        /// </summary>
+        /// <typeparam name="TValue">The type of the value. Must be non-nullable.</typeparam>
+        /// <typeparam name="TError">The type of the error. Must be non-nullable.</typeparam>
+        /// <param name="result">The source result.</param>
+        /// <returns>The success value contained in <paramref name="result"/>.</returns>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="result"/> is in a failure state.</exception>
+        public static TValue Unwrap<TValue, TError>(this Result<TValue, TError> result)
+            where TValue : notnull
             where TError : notnull
         {
             if (result.IsFailure)
@@ -608,16 +887,40 @@ namespace Dx.Domain
             return result.Value;
         }
 
-        public static Task<Result<T, TError>> AsTask<T, TError>(this Result<T, TError> result)
-            where T : notnull
+        /// <summary>
+        /// Wraps the result in a completed <see cref="Task{TResult}"/>.
+        /// </summary>
+        /// <typeparam name="TValue">The type of the value. Must be non-nullable.</typeparam>
+        /// <typeparam name="TError">The type of the error. Must be non-nullable.</typeparam>
+        /// <param name="result">The source result.</param>
+        /// <returns>A completed task containing <paramref name="result"/>.</returns>
+        public static Task<Result<TValue, TError>> AsTask<TValue, TError>(this Result<TValue, TError> result)
+            where TValue : notnull
             where TError : notnull
             => Task.FromResult(result);
 
-        public static ValueTask<Result<T, TError>> AsValueTask<T, TError>(this Result<T, TError> result)
-            where T : notnull
+        /// <summary>
+        /// Wraps the result in a completed <see cref="ValueTask{TResult}"/>.
+        /// </summary>
+        /// <typeparam name="TValue">The type of the value. Must be non-nullable.</typeparam>
+        /// <typeparam name="TError">The type of the error. Must be non-nullable.</typeparam>
+        /// <param name="result">The source result.</param>
+        /// <returns>A completed value task containing <paramref name="result"/>.</returns>
+        public static ValueTask<Result<TValue, TError>> AsValueTask<TValue, TError>(this Result<TValue, TError> result)
+            where TValue : notnull
             where TError : notnull
             => new(result);
 
+        /// <summary>
+        /// Converts a result with a generic error type to a result using <see cref="DomainError"/> by mapping the error.
+        /// </summary>
+        /// <typeparam name="TValue">The type of the value. Must be non-nullable.</typeparam>
+        /// <typeparam name="TError">The type of the source error. Must be non-nullable.</typeparam>
+        /// <param name="result">The source result.</param>
+        /// <param name="mapError">The function that maps the source error to a <see cref="DomainError"/>. Must not be <see langword="null"/>.</param>
+        /// <returns>A success result if <paramref name="result"/> is successful; otherwise, a failure containing the mapped <see cref="DomainError"/>.</returns>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="mapError"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="mapError"/> throws an exception. The original exception is included as the inner exception.</exception>
         public static Result<TValue> ToDomainError<TValue, TError>(this Result<TValue, TError> result, Func<TError, DomainError> mapError)
             where TValue : notnull
             where TError : notnull
@@ -643,8 +946,19 @@ namespace Dx.Domain
             }
         }
 
-        public static Result<T, TErrorOut> MapError<T, TErrorIn, TErrorOut>(this Result<T, TErrorIn> result, Func<TErrorIn, TErrorOut> mapError)
-            where T : notnull
+        /// <summary>
+        /// Transforms the error of a failure result using the specified mapping function.
+        /// </summary>
+        /// <typeparam name="TValue">The type of the value. Must be non-nullable.</typeparam>
+        /// <typeparam name="TErrorIn">The type of the source error. Must be non-nullable.</typeparam>
+        /// <typeparam name="TErrorOut">The type of the mapped error. Must be non-nullable.</typeparam>
+        /// <param name="result">The source result.</param>
+        /// <param name="mapError">The function that maps the error to a new error type. Must not be <see langword="null"/>.</param>
+        /// <returns>A success result if <paramref name="result"/> is successful; otherwise, a failure containing the mapped error.</returns>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="mapError"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvariantViolationException">Thrown when <paramref name="mapError"/> throws an exception. The original exception is included as the inner exception.</exception>
+        public static Result<TValue, TErrorOut> MapError<TValue, TErrorIn, TErrorOut>(this Result<TValue, TErrorIn> result, Func<TErrorIn, TErrorOut> mapError)
+            where TValue : notnull
             where TErrorIn : notnull
             where TErrorOut : notnull
         {
@@ -653,12 +967,12 @@ namespace Dx.Domain
                 "The error mapping function cannot be null.");
 
             if (result.IsSuccess)
-                return Result.Success<T, TErrorOut>(result.Value);
+                return Result.Success<TValue, TErrorOut>(result.Value);
 
             try
             {
                 var mappedError = mapError!(result.Error);
-                return Result.Failure<T, TErrorOut>(mappedError);
+                return Result.Failure<TValue, TErrorOut>(mappedError);
             }
             catch (Exception ex)
             {
@@ -673,43 +987,43 @@ namespace Dx.Domain
 
         #region Helpers
 
-        private static async Task<Result<T, TError>> TrySucceedAsync<T, TError>(Func<Task<T>> func, Func<Exception, TError> errorFactory)
-            where T : notnull
+        private static async Task<Result<TValue, TError>> TrySucceedAsync<TValue, TError>(Func<Task<TValue>> func, Func<Exception, TError> errorFactory)
+            where TValue : notnull
             where TError : notnull
         {
             try
             {
                 var result = await func().ConfigureAwait(false);
-                return Result.Success<T, TError>(result);
+                return Result.Success<TValue, TError>(result);
             }
             catch (Exception ex)
             {
-                return TryFail<T, TError>(ex, errorFactory);
+                return TryFail<TValue, TError>(ex, errorFactory);
             }
         }
 
-        private static Result<T, TError> TrySucceed<T, TError>(Func<T> func, Func<Exception, TError> errorFactory)
-            where T : notnull
+        private static Result<TValue, TError> TrySucceed<TValue, TError>(Func<TValue> func, Func<Exception, TError> errorFactory)
+            where TValue : notnull
             where TError : notnull
         {
             try
             {
                 var result = func();
-                return Result.Success<T, TError>(result);
+                return Result.Success<TValue, TError>(result);
             }
             catch (Exception ex)
             {
-                return TryFail<T, TError>(ex, errorFactory);
+                return TryFail<TValue, TError>(ex, errorFactory);
             }
         }
 
-        private static Result<T, TError> TryFail<T, TError>(Exception ex, Func<Exception, TError> errorFactory)
-            where T : notnull
+        private static Result<TValue, TError> TryFail<TValue, TError>(Exception ex, Func<Exception, TError> errorFactory)
+            where TValue : notnull
             where TError : notnull
         {
             try
             {
-                return Result.Failure<T, TError>(errorFactory(ex));
+                return Result.Failure<TValue, TError>(errorFactory(ex));
             }
             catch (Exception ex2)
             {

--- a/src/Dx.Domain.Kernel/Result{TValue, TError}.cs
+++ b/src/Dx.Domain.Kernel/Result{TValue, TError}.cs
@@ -73,7 +73,7 @@ namespace Dx.Domain
         /// <summary>
         /// Initializes a new instance of the Result class that represents a failed result with the specified error.
         /// </summary>
-        /// <param name="error">The error value associated with the failed Result. Cannot be null if TError is a reference type.</param>
+        /// <param name="error">The error value associated with the failed Result. Cannot be <see langword="null"/> if TError is a reference type.</param>
         private Result(TError error) => _error = error;
 
         /// <summary>

--- a/src/Dx.Domain.Primitives/CorrelationId.cs
+++ b/src/Dx.Domain.Primitives/CorrelationId.cs
@@ -77,13 +77,13 @@ namespace Dx.Domain.Primitives
         /// General-purpose span formatting implementation used by composite formatting APIs.
         /// </summary>
         /// <remarks>
-        /// If <paramref name="format"/> is null or empty, defaults to canonical format (<c>"N"</c>).
-        /// If <paramref name="provider"/> is null, uses <see cref="CultureInfo.InvariantCulture"/>.
+        /// If <paramref name="format"/> is <see langword="null"/> or empty, defaults to canonical format (<c>"N"</c>).
+        /// If <paramref name="provider"/> is <see langword="null"/>, uses <see cref="CultureInfo.InvariantCulture"/>.
         /// </remarks>
         /// <param name="destination">The span to write the formatted value into.</param>
         /// <param name="charsWritten">When this method returns, contains the number of characters written to the destination.</param>
-        /// <param name="format">The format specifier. If null or empty, defaults to <c>"N"</c>.</param>
-        /// <param name="provider">The format provider. If null, uses <see cref="CultureInfo.InvariantCulture"/>.</param>
+        /// <param name="format">The format specifier. If <see langword="null"/> or empty, defaults to <c>"N"</c>.</param>
+        /// <param name="provider">The format provider. If <see langword="null"/>, uses <see cref="CultureInfo.InvariantCulture"/>.</param>
         /// <returns><see langword="true"/> if formatting succeeded; otherwise, <see langword="false"/>.</returns>
         public bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format, IFormatProvider? provider)
         {
@@ -109,11 +109,11 @@ namespace Dx.Domain.Primitives
         /// Formats this identifier as a string using the specified format and culture.
         /// </summary>
         /// <remarks>
-        /// If <paramref name="format"/> is null or empty, defaults to canonical format (<c>"N"</c>).
-        /// If <paramref name="formatProvider"/> is null, uses <see cref="CultureInfo.InvariantCulture"/>.
+        /// If <paramref name="format"/> is <see langword="null"/> or empty, defaults to canonical format (<c>"N"</c>).
+        /// If <paramref name="formatProvider"/> is <see langword="null"/>, uses <see cref="CultureInfo.InvariantCulture"/>.
         /// </remarks>
-        /// <param name="format">The format specifier. If null or empty, defaults to <c>"N"</c>.</param>
-        /// <param name="formatProvider">The format provider. If null, uses <see cref="CultureInfo.InvariantCulture"/>.</param>
+        /// <param name="format">The format specifier. If <see langword="null"/> or empty, defaults to <c>"N"</c>.</param>
+        /// <param name="formatProvider">The format provider. If <see langword="null"/>, uses <see cref="CultureInfo.InvariantCulture"/>.</param>
         /// <returns>A string representation of this correlation identifier.</returns>
         public string ToString(string? format, IFormatProvider? formatProvider)
             => Value.ToString(string.IsNullOrEmpty(format) ? "N" : format!, formatProvider ?? CultureInfo.InvariantCulture);

--- a/src/Dx.Domain.Primitives/Dx.Domain.Primitives.csproj
+++ b/src/Dx.Domain.Primitives/Dx.Domain.Primitives.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <DxIsLibrary>true</DxIsLibrary>
     <DxLayer>Primitives</DxLayer>
@@ -12,7 +12,8 @@
     <Authors>Dx.Domain Team</Authors>
     <Company>Dx.Domain Team</Company>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <NoWarn>$(NoWarn);CS1591;DX1001</NoWarn>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+    <!--<NoWarn>$(NoWarn);CS1591;DX1001</NoWarn>-->
     <Nullable>enable</Nullable>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/ulfbou/dx.domain</RepositoryUrl>
@@ -39,8 +40,8 @@
           PackagePath="analyzers/dotnet/cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Update="CHANGELOG.md" Link="docs/CHANGELOG.md" />
-    <None Update="README.md" Link="docs/README.md" />
+    <None Include="CHANGELOG.md" Pack="true" PackagePath="/" />
+    <None Include="README.md" Pack="true" PackagePath="/" />
     <None Update="..\..\LICENSE" Link="docs/LICENSE" />
   </ItemGroup>
 

--- a/src/Dx.Domain.Primitives/TraceId.cs
+++ b/src/Dx.Domain.Primitives/TraceId.cs
@@ -167,7 +167,7 @@ namespace Dx.Domain.Primitives
         /// <param name="provider">The format provider. This parameter is currently ignored.</param>
         /// <returns><see langword="true"/> if formatting succeeded; otherwise, <see langword="false"/>.</returns>
         /// <remarks>
-        /// If <paramref name="format"/> is null or empty, defaults to the canonical 32-character hex format.
+        /// If <paramref name="format"/> is <see langword="null"/> or empty, defaults to the canonical 32-character hex format.
         /// The <paramref name="provider"/> parameter is currently ignored.
         /// </remarks>
         public bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format, IFormatProvider? provider)

--- a/src/Dx.Domain.Primitives/UserId.cs
+++ b/src/Dx.Domain.Primitives/UserId.cs
@@ -82,12 +82,12 @@ namespace Dx.Domain.Primitives
         /// </summary>
         /// <param name="destination">The span to write the formatted value into.</param>
         /// <param name="charsWritten">When this method returns, contains the number of characters written to the destination.</param>
-        /// <param name="format">The format specifier. If null or empty, defaults to <c>"N"</c>.</param>
-        /// <param name="provider">The format provider. If null, uses <see cref="CultureInfo.InvariantCulture"/>.</param>
+        /// <param name="format">The format specifier. If <see langword="null"/> or empty, defaults to <c>"N"</c>.</param>
+        /// <param name="provider">The format provider. If <see langword="null"/>, uses <see cref="CultureInfo.InvariantCulture"/>.</param>
         /// <returns><see langword="true"/> if formatting succeeded; otherwise, <see langword="false"/>.</returns>
         /// <remarks>
-        /// If <paramref name="format"/> is null or empty, defaults to canonical format (<c>"N"</c>).
-        /// If <paramref name="provider"/> is null, uses <see cref="CultureInfo.InvariantCulture"/>.
+        /// If <paramref name="format"/> is <see langword="null"/> or empty, defaults to canonical format (<c>"N"</c>).
+        /// If <paramref name="provider"/> is <see langword="null"/>, uses <see cref="CultureInfo.InvariantCulture"/>.
         /// </remarks>
         public bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format, IFormatProvider? provider)
         {
@@ -115,11 +115,11 @@ namespace Dx.Domain.Primitives
         /// Formats this identifier as a string using the specified format and culture.
         /// </summary>
         /// <remarks>
-        /// If <paramref name="format"/> is null or empty, defaults to canonical format (<c>"N"</c>).
-        /// If <paramref name="formatProvider"/> is null, uses <see cref="CultureInfo.InvariantCulture"/>.
+        /// If <paramref name="format"/> is <see langword="null"/> or empty, defaults to canonical format (<c>"N"</c>).
+        /// If <paramref name="formatProvider"/> is <see langword="null"/>, uses <see cref="CultureInfo.InvariantCulture"/>.
         /// </remarks>
-        /// <param name="format">The format specifier. If null or empty, defaults to <c>"N"</c>.</param>
-        /// <param name="formatProvider">The format provider. If null, uses <see cref="CultureInfo.InvariantCulture"/>.</param>
+        /// <param name="format">The format specifier. If <see langword="null"/> or empty, defaults to <c>"N"</c>.</param>
+        /// <param name="formatProvider">The format provider. If <see langword="null"/>, uses <see cref="CultureInfo.InvariantCulture"/>.</param>
         /// <returns>A string representation of this actor identifier.</returns>
         public string ToString(string? format, IFormatProvider? formatProvider)
             => Value.ToString(string.IsNullOrEmpty(format) ? "N" : format!, formatProvider ?? CultureInfo.InvariantCulture);


### PR DESCRIPTION
﻿## Description
Normalizes XML documentation across all core packages to meet DocFX requirements and improve API reference quality.

## Type of Change
- [x] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related Issues
Relates to #20

## Changes Made
- Add standardized XML copyright headers to 11 source files
- Replace plain "null" with `<see langword="null"/>` in XML docs
- Add 700+ lines of XML documentation to ResultExtensions and ResultExtensionsGeneric
- Add missing documentation to DomainTime, DomainError, Causation, and Fact types
- Ensure all public APIs have complete <summary>, <param>, and <exception> tags

## Testing
- [x] `dotnet build -c Release` passes with documentation generation
- [x] No CS1591 warnings
- [x] DocFX builds successfully

## Breaking Changes
None - documentation only
