### PR TITLE
chore(release): v0.1.0-alpha readiness — DXA040, DXA065, commitlint

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,6 +1,12 @@
 {
-  "extends": ["@commitlint/config-conventional"],
+  "extends": [ "@commitlint/config-conventional" ],
   "rules": {
-    "type-enum": [2, "always", ["feat","fix","chore","docs","refactor","perf","test","ci","build"]]
+    "type-enum": [
+      2,
+      "always",
+      [ "feat", "fix", "chore", "docs", "refactor", "perf", "test", "ci", "build" ]
+    ],
+    "body-max-line-length": [ 0, "always" ],
+    "header-max-length": [ 2, "always", 100 ]
   }
 }

--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,0 +1,6 @@
+{
+  "extends": ["@commitlint/config-conventional"],
+  "rules": {
+    "type-enum": [2, "always", ["feat","fix","chore","docs","refactor","perf","test","ci","build"]]
+  }
+}

--- a/.github/workflows/build-validate.yml
+++ b/.github/workflows/build-validate.yml
@@ -13,6 +13,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Commit lint
+        uses: wagoid/commitlint-github-action@v5
+        with:
+          configFile: .commitlintrc.json
 
       - name: Setup .NET SDKs
         uses: actions/setup-dotnet@v4

--- a/.github/workflows/build-validate.yml
+++ b/.github/workflows/build-validate.yml
@@ -20,6 +20,7 @@ jobs:
         uses: wagoid/commitlint-github-action@v5
         with:
           configFile: .commitlintrc.json
+          commitDepth: true
 
       - name: Setup .NET SDKs
         uses: actions/setup-dotnet@v4

--- a/.github/workflows/build-validate.yml
+++ b/.github/workflows/build-validate.yml
@@ -20,7 +20,8 @@ jobs:
         uses: wagoid/commitlint-github-action@v5
         with:
           configFile: .commitlintrc.json
-          commitDepth: true
+          commitDepth: 1
+          failOnWarnings: false
 
       - name: Setup .NET SDKs
         uses: actions/setup-dotnet@v4

--- a/global.json
+++ b/global.json
@@ -1,5 +1,7 @@
 {
   "sdk": {
-    "version": "10.0.202"
+    "version": "10.0.100",
+    "rollForward": "latestFeature",
+    "allowPrerelease": true
   }
 }

--- a/src/Dx.Domain.Analyzers/Infrastructure/Generated/GeneratedCodeDetector.cs
+++ b/src/Dx.Domain.Analyzers/Infrastructure/Generated/GeneratedCodeDetector.cs
@@ -25,7 +25,8 @@ namespace Dx.Domain.Analyzers.Infrastructure.Generated
     /// </summary>
     /// <remarks>
     /// This type is used exclusively by analyzers to suppress diagnostics on generated sources.
-    /// Detection is based on <see cref="GeneratedCodeAttribute"/>, <c>CompilerGeneratedAttribute</c>, and namespace markers configured via the <c>dx_generated_markers</c> analyzer option.
+    /// Detection is based on <see cref="GeneratedCodeAttribute"/>, <c>CompilerGeneratedAttribute</c>,
+    /// and namespace markers configured via the <c>dx_generated_markers</c> analyzer option.
     /// It carries analysis configuration only and imposes no runtime semantics outside compilation analysis.
     /// </remarks>
     public sealed class GeneratedCodeDetector : IGeneratedCodeDetector

--- a/src/Dx.Domain.Analyzers/Infrastructure/IExceptionIntentClassifier.cs
+++ b/src/Dx.Domain.Analyzers/Infrastructure/IExceptionIntentClassifier.cs
@@ -18,7 +18,8 @@ namespace Dx.Domain.Analyzers.Infrastructure
     /// Defines a contract for classifying exception throw operations by their intent.
     /// </summary>
     /// <remarks>
-    /// This interface is used exclusively by analyzers to distinguish guard failures from domain faults. It carries analysis data only and imposes no runtime semantics outside compilation analysis.
+    /// This interface is used exclusively by analyzers to distinguish guard failures from domain faults.
+    /// It carries analysis data only and imposes no runtime semantics outside compilation analysis.
     /// </remarks>
     public interface IExceptionIntentClassifier
     {

--- a/src/Dx.Domain.Analyzers/Infrastructure/Scopes/IScopeResolver.cs
+++ b/src/Dx.Domain.Analyzers/Infrastructure/Scopes/IScopeResolver.cs
@@ -18,7 +18,8 @@ namespace Dx.Domain.Analyzers.Infrastructure.Scopes
     /// Defines a contract for resolving architectural scope for assemblies and symbols.
     /// </summary>
     /// <remarks>
-    /// This interface is used exclusively by analyzers to enforce layering rules. It carries analysis configuration only and imposes no runtime semantics outside compilation analysis.
+    /// This interface is used exclusively by analyzers to enforce layering rules. It carries analysis configuration
+    /// only and imposes no runtime semantics outside compilation analysis.
     /// </remarks>
     public interface IScopeResolver
     {

--- a/src/Dx.Domain.Analyzers/Infrastructure/Scopes/Scope.cs
+++ b/src/Dx.Domain.Analyzers/Infrastructure/Scopes/Scope.cs
@@ -16,7 +16,8 @@ namespace Dx.Domain.Analyzers.Infrastructure.Scopes
     /// Defines architectural scope classification vocabulary for analyzers.
     /// </summary>
     /// <remarks>
-    /// This enumeration imposes no runtime semantics. It is pure analyzer metadata interpreted exclusively by Dx.Domain analyzers. Values are part of the public analyzer contract and must remain stable.
+    /// This enumeration imposes no runtime semantics. It is pure analyzer metadata interpreted exclusively by
+    /// Dx.Domain analyzers. Values are part of the public analyzer contract and must remain stable.
     /// </remarks>
     public enum Scope
     {

--- a/src/Dx.Domain.Annotations/DpiJustifiedAttribute.cs
+++ b/src/Dx.Domain.Annotations/DpiJustifiedAttribute.cs
@@ -18,7 +18,8 @@ namespace Dx.Domain.Annotations;
 /// Documents a deviation from standard patterns with a DPI-aligned justification (pure metadata marker).
 /// </summary>
 /// <remarks>
-/// This attribute imposes no runtime semantics. It records rationale for code review and audit trails. See Governance Docs → DPI / ADR Process.
+/// This attribute imposes no runtime semantics. It records rationale for code review and audit trails.
+/// See Governance Docs → DPI / ADR Process.
 ///
 /// <para><b>Example (non‑prescriptive):</b></para>
 /// <code><![CDATA[

--- a/src/Dx.Domain.Annotations/DxFacadeAttribute.cs
+++ b/src/Dx.Domain.Annotations/DxFacadeAttribute.cs
@@ -18,7 +18,8 @@ namespace Dx.Domain.Annotations;
 /// Marks a class as an approved domain facade boundary (pure metadata marker).
 /// </summary>
 /// <remarks>
-/// This attribute imposes no runtime semantics. Analyzers classify construction boundaries per DXA010/011/080. See Rule Charter → DXA010 Construction Discipline.
+/// This attribute imposes no runtime semantics. Analyzers classify construction boundaries
+/// per DXA010/011/080. See Rule Charter → DXA010 Construction Discipline.
 ///
 /// <para><b>Example (Kernel realization, non‑prescriptive):</b></para>
 /// <code><![CDATA[

--- a/src/Dx.Domain.Kernel/DomainTime.cs
+++ b/src/Dx.Domain.Kernel/DomainTime.cs
@@ -30,6 +30,7 @@ namespace Dx.Domain
     /// The <see cref="Utc"/> value is always normalized to UTC with an offset of zero.
     /// </para>
     /// </remarks>
+    [ApprovedKernelApi("UTC timestamp primitive for deterministic time invariants")]
     public readonly record struct DomainTime
     {
         /// <summary>

--- a/src/Dx.Domain.Kernel/Errors/DomainError.cs
+++ b/src/Dx.Domain.Kernel/Errors/DomainError.cs
@@ -22,6 +22,7 @@ namespace Dx.Domain.Errors
     /// Errors are value objects: immutable, explicit, and non-exceptional by default.
     /// </summary>
     [DebuggerDisplay("{Code,nq}")]
+    [ApprovedKernelApi("Error value object for explicit result propagation")]
     public readonly struct DomainError : IEquatable<DomainError>
     {
         /// <summary>

--- a/src/Dx.Domain.Kernel/Result{TValue, TError}.cs
+++ b/src/Dx.Domain.Kernel/Result{TValue, TError}.cs
@@ -22,13 +22,14 @@ namespace Dx.Domain
     /// Represents the immutable result of an operation that can succeed with a value of type <typeparamref name="TValue"/> or fail
     /// with an error of type <typeparamref name="TError"/>.
     /// </summary>
+    /// <typeparam name="TValue">The type of the value returned when the operation succeeds.</typeparam>
+    /// <typeparam name="TError">The type of the error returned when the operation fails.</typeparam>
     /// <remarks>
     /// This is the canonical functional result type, a discriminated union that explicitly models success and failure paths.
     /// Use <see cref="Result{TValue}"/> for the common case where <typeparamref name="TError"/> is fixed to <see cref="DomainError"/>.
     /// </remarks>
-    /// <typeparam name="TValue">The type of the value returned when the operation succeeds.</typeparam>
-    /// <typeparam name="TError">The type of the error returned when the operation fails.</typeparam>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    [ApprovedKernelApi("Generic Result<T,E> type for advanced functional patterns")]
     public readonly struct Result<TValue, TError> where TValue : notnull where TError : notnull
     {
         private readonly TValue? _value;
@@ -104,14 +105,14 @@ namespace Dx.Domain
         /// <summary>
         /// Deconstructs the result into its success status, value, and error information.
         /// </summary>
-        /// <remarks>This method enables deconstruction of the result into separate variables for pattern
-        /// matching or tuple assignment.</remarks>
         /// <param name="isSuccess">When this method returns, contains <see langword="true"/> if the result represents a success; otherwise,
         /// <see langword="false"/>.</param>
         /// <param name="value">When this method returns, contains the value of the result if it is successful; otherwise, the default value
         /// for the type.</param>
         /// <param name="error">When this method returns, contains the error information if the result represents a failure; otherwise, <see
         /// langword="null"/>.</param>
+        /// <remarks>This method enables deconstruction of the result into separate variables for pattern
+        /// matching or tuple assignment.</remarks>
         public void Deconstruct(out bool isSuccess, out TValue? value, out TError? error)
         {
             isSuccess = IsSuccess;
@@ -122,13 +123,13 @@ namespace Dx.Domain
         /// <summary>
         /// Deconstructs the result into its failure status, error, and value components.
         /// </summary>
-        /// <remarks>This method enables deconstruction syntax, allowing the result to be unpacked into
-        /// separate variables for failure status, error, and value.</remarks>
         /// <param name="isFailure">When this method returns, contains <see langword="true"/> if the result represents a failure; otherwise,
         /// <see langword="false"/>.</param>
         /// <param name="error">When this method returns, contains the associated <see cref="DomainError"/> if the result is a failure;
         /// otherwise, <see langword="null"/>.</param>
         /// <param name="value">When this method returns, contains the value if the result is successful; otherwise, <see langword="null"/>.</param>
+        /// <remarks>This method enables deconstruction syntax, allowing the result to be unpacked into
+        /// separate variables for failure status, error, and value.</remarks>
         public void Deconstruct(out bool isFailure, out TError? error, out TValue? value)
         {
             isFailure = IsFailure;
@@ -139,10 +140,10 @@ namespace Dx.Domain
         /// <summary>
         /// Deconstructs the result into its value component.
         /// </summary>
-        /// <remarks>This method enables deconstruction syntax, allowing the result to be unpacked into its value
-        /// component using tuple deconstruction.</remarks>
         /// <param name="value">When this method returns, contains the value if the operation was successful; otherwise, the default value for the
         /// type.</param>
+        /// <remarks>This method enables deconstruction syntax, allowing the result to be unpacked into its value
+        /// component using tuple deconstruction.</remarks>
         public void Deconstruct(out TValue? value)
         {
             value = _value;
@@ -153,6 +154,8 @@ namespace Dx.Domain
         /// </summary>
         /// <param name="error">When this method returns, contains the associated error if the result is a failure; otherwise, <see
         /// langword="null"/>.</param>
+        /// <remarks>This method enables deconstruction syntax, allowing the result to be unpacked into its error
+        /// component using tuple deconstruction.</remarks>
         public void Deconstruct(out TError? error)
         {
             error = _error;

--- a/src/Dx.Domain.Kernel/Result{TValue}.cs
+++ b/src/Dx.Domain.Kernel/Result{TValue}.cs
@@ -25,6 +25,7 @@ namespace Dx.Domain
     /// </summary>
     /// <typeparam name="TValue">Successful value type.</typeparam>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    [ApprovedKernelApi("Canonical Result<T> type for functional error handling")]
     public readonly struct Result<TValue> where TValue : notnull
     {
         private readonly TValue? _value;

--- a/src/Dx.Domain.Kernel/Unit.cs
+++ b/src/Dx.Domain.Kernel/Unit.cs
@@ -18,6 +18,7 @@ namespace Dx.Domain
     /// Unit type used for Result operations that return no value.
     /// </summary>
     [DebuggerDisplay("Unit")]
+    [ApprovedKernelApi("Void-like type for operations with no return value")]
     public readonly record struct Unit
     {
         /// <summary>Gets the singleton value of the Unit type.</summary>

--- a/src/Dx.Domain.Primitives/CorrelationId.cs
+++ b/src/Dx.Domain.Primitives/CorrelationId.cs
@@ -76,15 +76,15 @@ namespace Dx.Domain.Primitives
         /// <summary>
         /// General-purpose span formatting implementation used by composite formatting APIs.
         /// </summary>
-        /// <remarks>
-        /// If <paramref name="format"/> is <see langword="null"/> or empty, defaults to canonical format (<c>"N"</c>).
-        /// If <paramref name="provider"/> is <see langword="null"/>, uses <see cref="CultureInfo.InvariantCulture"/>.
-        /// </remarks>
         /// <param name="destination">The span to write the formatted value into.</param>
         /// <param name="charsWritten">When this method returns, contains the number of characters written to the destination.</param>
         /// <param name="format">The format specifier. If <see langword="null"/> or empty, defaults to <c>"N"</c>.</param>
         /// <param name="provider">The format provider. If <see langword="null"/>, uses <see cref="CultureInfo.InvariantCulture"/>.</param>
         /// <returns><see langword="true"/> if formatting succeeded; otherwise, <see langword="false"/>.</returns>
+        /// <remarks>
+        /// If <paramref name="format"/> is <see langword="null"/> or empty, defaults to canonical format (<c>"N"</c>).
+        /// If <paramref name="provider"/> is <see langword="null"/>, uses <see cref="CultureInfo.InvariantCulture"/>.
+        /// </remarks>
         public bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format, IFormatProvider? provider)
         {
             var normalizedFormat = format.IsEmpty ? "N" : format;
@@ -108,13 +108,13 @@ namespace Dx.Domain.Primitives
         /// <summary>
         /// Formats this identifier as a string using the specified format and culture.
         /// </summary>
+        /// <param name="format">The format specifier. If <see langword="null"/> or empty, defaults to <c>"N"</c>.</param>
+        /// <param name="formatProvider">The format provider. If <see langword="null"/>, uses <see cref="CultureInfo.InvariantCulture"/>.</param>
+        /// <returns>A string representation of this correlation identifier.</returns>
         /// <remarks>
         /// If <paramref name="format"/> is <see langword="null"/> or empty, defaults to canonical format (<c>"N"</c>).
         /// If <paramref name="formatProvider"/> is <see langword="null"/>, uses <see cref="CultureInfo.InvariantCulture"/>.
         /// </remarks>
-        /// <param name="format">The format specifier. If <see langword="null"/> or empty, defaults to <c>"N"</c>.</param>
-        /// <param name="formatProvider">The format provider. If <see langword="null"/>, uses <see cref="CultureInfo.InvariantCulture"/>.</param>
-        /// <returns>A string representation of this correlation identifier.</returns>
         public string ToString(string? format, IFormatProvider? formatProvider)
             => Value.ToString(string.IsNullOrEmpty(format) ? "N" : format!, formatProvider ?? CultureInfo.InvariantCulture);
 

--- a/src/Dx.Domain.Primitives/SpanId.cs
+++ b/src/Dx.Domain.Primitives/SpanId.cs
@@ -144,15 +144,15 @@ namespace Dx.Domain.Primitives
         /// <summary>
         /// Formats this identifier as a string using the specified format and culture.
         /// </summary>
-        /// <remarks>
-        /// If <paramref name="format"/> is <see langword="null"/> or empty, defaults to canonical format (<c>"x16"</c>).
-        /// If <paramref name="formatProvider"/> is <see langword="null"/>, uses <see cref="CultureInfo.InvariantCulture"/>.
-        /// </remarks>
         /// <param name="format">The format specifier. If <see langword="null"/> or empty, defaults to <c>"x16"</c>.</param>
         /// <param name="formatProvider">
         /// The format provider. If <see langword="null"/>, uses <see cref="CultureInfo.InvariantCulture"/>.
         /// </param>
         /// <returns>A formatted string representation of this identifier.</returns>
+        /// <remarks>
+        /// If <paramref name="format"/> is <see langword="null"/> or empty, defaults to canonical format (<c>"x16"</c>).
+        /// If <paramref name="formatProvider"/> is <see langword="null"/>, uses <see cref="CultureInfo.InvariantCulture"/>.
+        /// </remarks>
         public string ToString(string? format, IFormatProvider? formatProvider)
             => Value.ToString(string.IsNullOrEmpty(format) ? "x16" : format!, formatProvider ?? CultureInfo.InvariantCulture);
 

--- a/src/Dx.Domain.Primitives/UserId.cs
+++ b/src/Dx.Domain.Primitives/UserId.cs
@@ -114,13 +114,13 @@ namespace Dx.Domain.Primitives
         /// <summary>
         /// Formats this identifier as a string using the specified format and culture.
         /// </summary>
+        /// <param name="format">The format specifier. If <see langword="null"/> or empty, defaults to <c>"N"</c>.</param>
+        /// <param name="formatProvider">The format provider. If <see langword="null"/>, uses <see cref="CultureInfo.InvariantCulture"/>.</param>
+        /// <returns>A string representation of this actor identifier.</returns>
         /// <remarks>
         /// If <paramref name="format"/> is <see langword="null"/> or empty, defaults to canonical format (<c>"N"</c>).
         /// If <paramref name="formatProvider"/> is <see langword="null"/>, uses <see cref="CultureInfo.InvariantCulture"/>.
         /// </remarks>
-        /// <param name="format">The format specifier. If <see langword="null"/> or empty, defaults to <c>"N"</c>.</param>
-        /// <param name="formatProvider">The format provider. If <see langword="null"/>, uses <see cref="CultureInfo.InvariantCulture"/>.</param>
-        /// <returns>A string representation of this actor identifier.</returns>
         public string ToString(string? format, IFormatProvider? formatProvider)
             => Value.ToString(string.IsNullOrEmpty(format) ? "N" : format!, formatProvider ?? CultureInfo.InvariantCulture);
 


### PR DESCRIPTION
﻿## Description
Final governance changes for v0.1.0-alpha. Adds DXA040 DPI justifications to Kernel public surface, normalizes XML documentation for DXA065 compliance, and enforces conventional commits in CI.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Configuration change
- [x] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Related Issues
Closes #29

## Changes Made
- Added [ApprovedKernelApi] to 5 Kernel types: Result<T>, Result<T,E>, Unit, DomainTime, DomainError
- Reordered XML documentation tags in Kernel, Primitives, Annotations, and Analyzers for DXA065 compliance
- Added commitlint step to.github/workflows/build-validate.yml with fetch-depth:0
- Added.commitlintrc.json with conventional types

## Testing
### Test Configuration
- **OS**: Windows 11
- **.NET Version**: 8.0 / 9.0 / 10.0
- **Branch**: chore/v0.1.0-alpha-readiness

### Test Results
- [x] All existing unit tests pass
- [ ] Added new tests for changes
- [ ] Integration tests pass (if applicable)
- [x] Manual testing performed

### Test Coverage
`ash
dotnet build -c Release
dotnet test -c Release --no-build
# Result: 53 passed, 0 failed, 0 warnings in src/
`

## Documentation
- Updated code comments/XML documentation
- [ ] Updated README.md (if needed)
- [ ] Updated conceptual docs in docs/ (if needed)
- [ ] Added/updated examples (if needed)
- [ ] Reviewed DocFX preview[x]

## CI/CD Checklist
- [ ] Pre-merge CI passed
- Code follows style guidelines
- No new warnings introduced
- Security scan passed
- No vulnerable dependencies
- Commit messages follow conventional commits[x]

## Breaking Changes
### Impact
None. Metadata-only attributes and documentation reordering. No runtime semantics changed.

### Migration Guide
N/A

## Additional Context
Build output: 0 warnings in shipped projects (2 CS8601 warnings in tests only, acceptable per governance). All 4 packages build for net8.0/net9.0/net10.0.

## Reviewer Notes
Focus on DXA040 justifications and XML doc ordering — these unblock the alpha release gate.
